### PR TITLE
Issue #33 Authenticated employee account creation + open registration endpoint

### DIFF
--- a/client/src/app/components/create-members/create-members.component.html
+++ b/client/src/app/components/create-members/create-members.component.html
@@ -1,1 +1,3 @@
 <p>Inside {{view}} Component</p>
+
+<app-signup></app-signup>

--- a/client/src/app/components/login/login.component.ts
+++ b/client/src/app/components/login/login.component.ts
@@ -38,7 +38,7 @@ export class LoginComponent implements OnInit {
       password: this.loginForm.value.password,
     };
 
-    this.authService.loginSysAdmin(this.body).subscribe(
+    this.authService.login(this.body).subscribe(
       (data) => {
         this.tokenService.SetToken(data.token); // Setting token in cookie for logged in users
         setTimeout(() => {

--- a/client/src/app/components/modify-members/modify-members.component.html
+++ b/client/src/app/components/modify-members/modify-members.component.html
@@ -1,5 +1,5 @@
 <p>Inside {{view}} Component</p>
-<button (click)="obtainClients()">Obtain Clients</button>
+<button mat-button (click)="obtainClients()">Obtain Clients</button>
 <ul *ngFor="let pers of users">
     <li>
         username = {{pers.user_name}},

--- a/client/src/app/components/signup/signup.component.html
+++ b/client/src/app/components/signup/signup.component.html
@@ -7,22 +7,15 @@
   </mat-card-header>
 
   <mat-card-content>
-    <form
-      class="col s12"
-      [formGroup]="signupForm"
-      novalidate
-      (ngSubmit)="signupUser()"
-    >
+    <form class="col s12" [formGroup]="signupForm" novalidate (ngSubmit)="signupUser()">
       <mat-form-field appearance="legacy">
         <input matInput id="user_name" type="text" formControlName="username" />
         <mat-label for="username">Username</mat-label>
-        <mat-error
-          class="error"
-          *ngIf="
+        <mat-error class="error" *ngIf="
             !signupForm.controls['username'].valid &&
             signupForm.controls['username'].touched
-          "
-          ><!-- Handeling error -->
+          ">
+          <!-- Handeling error -->
           Username is required
         </mat-error>
       </mat-form-field>
@@ -30,75 +23,60 @@
       <mat-form-field appearance="legacy">
         <input matInput id="email" type="email" formControlName="email" />
         <mat-label for="email">Email</mat-label>
-        <mat-error
-          class="error"
-          *ngIf="
+        <mat-error class="error" *ngIf="
             !signupForm.controls['email'].valid &&
             signupForm.controls['email'].touched
-          "
-          ><!-- Handeling error -->
+          ">
+          <!-- Handeling error -->
           Email is required
         </mat-error>
       </mat-form-field>
 
       <mat-form-field appearance="legacy">
-        <input
-          matInput
-          id="pass-word"
-          type="password"
-          formControlName="password"
-        />
+        <input matInput id="pass-word" type="password" formControlName="password" />
         <mat-label for="pass-word">Password</mat-label>
-        <mat-error
-          class="error"
-          *ngIf="
+        <mat-error class="error" *ngIf="
             !signupForm.controls['password'].valid &&
             signupForm.controls['password'].touched
-          "
-          ><!-- Handeling error -->
+          ">
+          <!-- Handeling error -->
           Password is required
         </mat-error>
       </mat-form-field>
       <mat-form-field appearance="legacy">
-        <input
-          matInput
-          id="firstname"
-          type="text"
-          formControlName="firstname"
-        />
+        <input matInput id="firstname" type="text" formControlName="firstname" />
         <mat-label for="firstname">Firstname</mat-label>
-        <mat-error
-          class="error"
-          *ngIf="
+        <mat-error class="error" *ngIf="
             !signupForm.controls['firstname'].valid &&
             signupForm.controls['firstname'].touched
-          "
-          ><!-- Handeling error -->
+          ">
+          <!-- Handeling error -->
           Firstname is required
         </mat-error>
       </mat-form-field>
       <mat-form-field appearance="legacy">
         <input matInput id="lastname" type="text" formControlName="lastname" />
         <mat-label for="lastname">lastname</mat-label>
-        <mat-error
-          class="error"
-          *ngIf="
+        <mat-error class="error" *ngIf="
             !signupForm.controls['lastname'].valid &&
             signupForm.controls['lastname'].touched
-          "
-          ><!-- Handeling error -->
+          ">
+          <!-- Handeling error -->
           lastname is required
         </mat-error>
       </mat-form-field>
       <br />
-      <button
-        mat-button
-        class="btn waves-effect"
-        id="signupbtn"
-        [disabled]="!signupForm.valid"
-      >
-        Sign Up</button
-      ><!-- if checks throws error then do not send data -->
+      <label for="role">Member Role</label>
+      <br />
+      <select formControlName="role">
+        <option value="">Choose a role</option>
+        <option *ngFor="let role of roles" [ngValue]="role">
+          {{ role.name }}
+        </option>
+      </select>
+      <br />
+      <button mat-button class="btn waves-effect" id="signupbtn" [disabled]="!signupForm.valid">
+        Sign Up</button><!-- if checks throws error then do not send data -->
     </form>
   </mat-card-content>
 </mat-card>

--- a/client/src/app/components/signup/signup.component.html
+++ b/client/src/app/components/signup/signup.component.html
@@ -66,15 +66,14 @@
         </mat-error>
       </mat-form-field>
       <br />
-      <label for="role">Member Role</label>
-      <br />
-      <select formControlName="role">
-        <option value="">Choose a role</option>
-        <option *ngFor="let role of roles" [ngValue]="role">
+      <mat-select formControlName="role">
+        <mat-option value="">Choose a role</mat-option>
+        <mat-option *ngFor="let role of roles" [value]="role">
           {{ role.name }}
-        </option>
-      </select>
+        </mat-option>
+      </mat-select>
       <br />
+      <br/>
       <button mat-button class="btn waves-effect" id="signupbtn" [disabled]="!signupForm.valid">
         Sign Up</button><!-- if checks throws error then do not send data -->
     </form>

--- a/client/src/app/components/signup/signup.component.ts
+++ b/client/src/app/components/signup/signup.component.ts
@@ -14,6 +14,11 @@ export class SignupComponent implements OnInit {
   signupForm: FormGroup;
   errorMessage: string;
   body: any;
+  roles = [
+    { name: 'System Admin', abbrev: 'SA' },
+    { name: 'Inventory Manager', abbrev: 'IM' },
+    { name: 'Stock Keeper', abbrev: 'SK' },
+  ];
 
   // Injecting the authService to be able to send data to the backend through it ,
   // fb for the formbuilder validations and Router to redirect to the desired component when registerd successfully
@@ -22,7 +27,7 @@ export class SignupComponent implements OnInit {
     private fb: FormBuilder,
     private router: Router,
     private tokenService: TokenService
-  ) {}
+  ) { }
 
   ngOnInit(): void {
     this.init();
@@ -36,6 +41,7 @@ export class SignupComponent implements OnInit {
       password: ['', Validators.required],
       firstname: ['', Validators.required],
       lastname: ['', Validators.required],
+      role: ['', Validators.required],
     });
   }
 
@@ -45,12 +51,13 @@ export class SignupComponent implements OnInit {
       email: this.signupForm.value.email,
       first_name: this.signupForm.value.firstname,
       last_name: this.signupForm.value.lastname,
-      role: 'SA',
+      role: this.signupForm.value.role.abbrev,
       is_active: 'true',
       password: this.signupForm.value.password,
     };
 
     // RegisterUser is the method defined in authService
+<<<<<<< HEAD
     this.authService.registerSysAdmin(this.body).subscribe(
       (data) => {
         this.tokenService.SetToken(data.token);
@@ -65,12 +72,30 @@ export class SignupComponent implements OnInit {
         if (err.error.email) {
           this.errorMessage = err.error.email[0];
         }
+=======
+    if (this.body.role === 'SA') {
+      this.authService.registerSysAdmin(this.body).subscribe(
+        (data) => {
+          this.tokenService.SetToken(data.token);
+          this.signupForm.reset(); // Reset form once signup
+          setTimeout(() => {
+            this.router.navigate(['']); // Redirect user to component in path:home (defined in alta-home-routing.module.ts)
+          }, 1000); // Waiting 3 seconds before redirecting the user
+        },
+        (err) => {
+          // 2 different types of error messages
+          // If email already exist
+          if (err.error.email) {
+            this.errorMessage = err.error.email[0];
+          }
+>>>>>>> 6aaa926... feat:Added the signup form(from the signup component) inside the create members component with a role drop down menu
 
-        // If username already exist
-        if (err.error.user_name) {
-          this.errorMessage = err.error.user_name[0];
+          // If username already exist
+          if (err.error.user_name) {
+            this.errorMessage = err.error.user_name[0];
+          }
         }
-      }
-    );
+      );
+    }
   }
 }

--- a/client/src/app/components/signup/signup.component.ts
+++ b/client/src/app/components/signup/signup.component.ts
@@ -56,12 +56,18 @@ export class SignupComponent implements OnInit {
       password: this.signupForm.value.password,
     };
     // RegisterUser is the method defined in authService
-    this.authService.register(this.body).subscribe(
+    // If you are not logged in you can create any account
+    // TODO: Disable in production
+    const register = this.tokenService.GetToken() ? this.authService.register(this.body) :
+      this.authService.openRegister(this.body);
+
+    register.subscribe(
       (data) => {
         this.tokenService.SetToken(data.token);
         this.signupForm.reset(); // Reset form once signup
         setTimeout(() => {
-          this.router.navigate(['modify-members']); // Redirect user to component in path:home (defined in alta-home-routing.module.ts)
+          // Redirect user to component in path:home (defined in alta-home-routing.module.ts)
+          this.router.navigate(['modify-members']);
         }, 1000); // Waiting 1 second before redirecting the user
       },
       (err) => {

--- a/client/src/app/components/signup/signup.component.ts
+++ b/client/src/app/components/signup/signup.component.ts
@@ -55,16 +55,14 @@ export class SignupComponent implements OnInit {
       is_active: 'true',
       password: this.signupForm.value.password,
     };
-
     // RegisterUser is the method defined in authService
-<<<<<<< HEAD
-    this.authService.registerSysAdmin(this.body).subscribe(
+    this.authService.register(this.body).subscribe(
       (data) => {
         this.tokenService.SetToken(data.token);
         this.signupForm.reset(); // Reset form once signup
         setTimeout(() => {
-          this.router.navigate(['']); // Redirect user to component in path:home (defined in alta-home-routing.module.ts)
-        }, 1000); // Waiting 1 seconds before redirecting the user
+          this.router.navigate(['modify-members']); // Redirect user to component in path:home (defined in alta-home-routing.module.ts)
+        }, 1000); // Waiting 1 second before redirecting the user
       },
       (err) => {
         // 2 different types of error messages
@@ -72,30 +70,12 @@ export class SignupComponent implements OnInit {
         if (err.error.email) {
           this.errorMessage = err.error.email[0];
         }
-=======
-    if (this.body.role === 'SA') {
-      this.authService.registerSysAdmin(this.body).subscribe(
-        (data) => {
-          this.tokenService.SetToken(data.token);
-          this.signupForm.reset(); // Reset form once signup
-          setTimeout(() => {
-            this.router.navigate(['']); // Redirect user to component in path:home (defined in alta-home-routing.module.ts)
-          }, 1000); // Waiting 3 seconds before redirecting the user
-        },
-        (err) => {
-          // 2 different types of error messages
-          // If email already exist
-          if (err.error.email) {
-            this.errorMessage = err.error.email[0];
-          }
->>>>>>> 6aaa926... feat:Added the signup form(from the signup component) inside the create members component with a role drop down menu
 
-          // If username already exist
-          if (err.error.user_name) {
-            this.errorMessage = err.error.user_name[0];
-          }
+        // If username already exist
+        if (err.error.user_name) {
+          this.errorMessage = err.error.user_name[0];
         }
-      );
-    }
+      }
+    );
   }
 }

--- a/client/src/app/components/toolbar/toolbar.component.html
+++ b/client/src/app/components/toolbar/toolbar.component.html
@@ -4,5 +4,5 @@
     </button>
     <h1 class="title">ALTA</h1>
     <span class="spacer"></span>
-    <button (click)="logout()">Logout</button>
+    <button mat-button (click)="logout()">Logout</button>
 </mat-toolbar>

--- a/client/src/app/modules/alta-main/alta-main.module.ts
+++ b/client/src/app/modules/alta-main/alta-main.module.ts
@@ -2,7 +2,7 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ReactiveFormsModule } from '@angular/forms';
 import { HttpClientModule } from '@angular/common/http';
-import { Router, RouterModule } from '@angular/router';
+import { RouterModule } from '@angular/router';
 import { HomeComponent } from 'src/app/components/home/home.component';
 import { AuthService } from 'src/app/services/auth.service';
 import { DashboardComponent } from 'src/app/components/dashboard/dashboard.component';
@@ -11,6 +11,8 @@ import { MatModule } from '../material/material-module';
 import { ManageMembersComponent } from 'src/app/components/manage-members/manage-members.component';
 import { ModifyMembersComponent } from 'src/app/components/modify-members/modify-members.component';
 import { ToolbarComponent } from 'src/app/components/toolbar/toolbar.component';
+import { CreateMembersComponent } from 'src/app/components/create-members/create-members.component';
+import { AuthModule } from '../auth/auth.module';
 
 @NgModule({
   declarations: [
@@ -19,13 +21,17 @@ import { ToolbarComponent } from 'src/app/components/toolbar/toolbar.component';
     DashboardComponent,
     SideNavComponent,
     ManageMembersComponent,
-    ModifyMembersComponent],
+    CreateMembersComponent,
+    ModifyMembersComponent,
+  ],
+
   imports: [
     CommonModule,
     MatModule,
     ReactiveFormsModule,
     HttpClientModule,
-    RouterModule
+    RouterModule,
+    AuthModule
   ],
   providers: [AuthService],
 

--- a/client/src/app/modules/material/material-module.ts
+++ b/client/src/app/modules/material/material-module.ts
@@ -21,6 +21,7 @@ import { MatSelectModule } from '@angular/material';
     MatButtonModule,
     MatFormFieldModule,
     MatInputModule,
+    MatSelectModule
   ],
   providers: [],
   exports: [
@@ -32,6 +33,7 @@ import { MatSelectModule } from '@angular/material';
     MatButtonModule,
     MatFormFieldModule,
     MatInputModule,
+    MatSelectModule
   ]
 })
 export class MatModule { }

--- a/client/src/app/modules/material/material-module.ts
+++ b/client/src/app/modules/material/material-module.ts
@@ -7,6 +7,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatTabsModule } from '@angular/material/tabs';
 import { MatCardModule } from '@angular/material/card';
 import { MatButtonModule } from '@angular/material/button';
+import { MatSelectModule } from '@angular/material';
 
 
 @NgModule({

--- a/client/src/app/services/auth.service.spec.ts
+++ b/client/src/app/services/auth.service.spec.ts
@@ -52,7 +52,7 @@ describe('AuthService', () => {
       // We run the registerSysAdmin function and we expect that the property name in the response that we
       // Will get when the request is carried (when the observable resolves) out is ‘angular’
       // (The same as in the mockSysAdmin).
-      authService.registerSysAdmin({}).subscribe((sysAdminData) => {
+      authService.register({}).subscribe((sysAdminData) => {
         expect(sysAdminData.user_name).toEqual('angular');
       });
 
@@ -70,14 +70,14 @@ describe('AuthService', () => {
   });
 
   // Test login
-  describe('#loginSysAdmin()', () => {
+  describe('#login()', () => {
     it('returned Observable should match the right data', () => {
       const mockSysAdmin2 = {
         user_name: 'angular',
         password: '12',
       };
 
-      authService.loginSysAdmin({}).subscribe((sysAdminData) => {
+      authService.login({}).subscribe((sysAdminData) => {
         expect(sysAdminData.user_name).toEqual('angular');
       });
 

--- a/client/src/app/services/auth.service.ts
+++ b/client/src/app/services/auth.service.ts
@@ -11,11 +11,11 @@ const BASEURL = 'http://localhost:8000';
 export class AuthService {
   constructor(private http: HttpClient) {} // We inject the http client in the constructor to do our REST operations
 
-  registerSysAdmin(body): Observable<any> {
+  register(body): Observable<any> {
     return this.http.post(`${BASEURL}/registration/`, body);
   }
 
-  loginSysAdmin(body): Observable<any> {
+  login(body): Observable<any> {
     return this.http.post(`${BASEURL}/login/`, body);
   }
 }

--- a/client/src/app/services/auth.service.ts
+++ b/client/src/app/services/auth.service.ts
@@ -15,6 +15,10 @@ export class AuthService {
     return this.http.post(`${BASEURL}/registration/`, body);
   }
 
+  openRegister(body): Observable<any> {
+    return this.http.post(`${BASEURL}/open-registration/`, body);
+  }
+
   login(body): Observable<any> {
     return this.http.post(`${BASEURL}/login/`, body);
   }

--- a/client/src/app/services/token-interceptor.spec.ts
+++ b/client/src/app/services/token-interceptor.spec.ts
@@ -45,7 +45,7 @@ describe('TokenInterceptor', () => {
   });
 
   it('should add content-type and Accept property in http header', () => {
-    authService.loginSysAdmin({}).subscribe((res) => {
+    authService.login({}).subscribe((res) => {
       expect(res).toBeTruthy();
     });
 

--- a/server/user_account/tests.py
+++ b/server/user_account/tests.py
@@ -4,6 +4,7 @@ from django.test.client import Client as HttpClient
 from rest_framework import status
 from rest_framework.test import APITestCase
 from rest_framework.authtoken.models import Token
+from rest_framework.test import APIClient
 from .models import CustomUser
 
 
@@ -67,6 +68,94 @@ class AccessAllClientsTestCase(TestCase):
         self.assertEqual(data[1]['last_name'], user2.last_name)
         self.assertEqual(data[1]['role'], user2.role)
 
+class RegistrationTestCase(APITestCase):
+    def setUp(self):
+        self.client = APIClient()
+        # Create each type of user that could be making the registration request
+        self.system_admin = CustomUser.objects.create(
+            user_name='system_admin',
+            email='system_admin@email.com',
+            password='password',
+            first_name='system',
+            last_name='admin',
+            role='SA',
+            is_active=True)
+
+        self.inventory_manager = CustomUser.objects.create(
+            user_name='inventory_manager',
+            email='inventory_manager@email.com',
+            password='password',
+            first_name='inventory',
+            last_name='manager',
+            role='IM',
+            is_active=True)
+
+        self.stock_keeper = CustomUser.objects.create(
+            user_name='stock_keeper',
+            email='stock_keeper@email.com',
+            password='password',
+            first_name='stock',
+            last_name='keeper',
+            role='SK',
+            is_active=True)
+
+        # Create each type of user that could be registered
+        self.registered_system_admin = {
+            'user_name': 'registered_SA',
+            'email': 'registered_SA@email.com',
+            'password': 'password',
+            'first_name': 'registered',
+            'last_name': 'system_admin',
+            'role': 'SA',
+            'is_active': 'True'}
+
+        self.registered_inventory_manager = {
+            'user_name': 'registered_IM',
+            'email': 'registered_IM@email.com',
+            'password': 'password',
+            'first_name': 'registered',
+            'last_name': 'inventory_manager',
+            'role': 'IM',
+            'is_active': 'True'}
+
+        self.registered_stock_keepeer = {
+            'user_name': 'registered_SK',
+            'email': 'registered_SK@email.com',
+            'password': 'password',
+            'first_name': 'registered',
+            'last_name': 'stock_keepeer',
+            'role': 'SK',
+            'is_active': 'True'}
+
+    def test_registration_success(self):
+        """ User was registered correctly """
+        # Authenticate a system admin
+        self.client.force_authenticate(user=self.system_admin)
+        request = self.client.post("/registration/", self.registered_system_admin)
+        self.assertEqual(request.status_code, status.HTTP_201_CREATED)
+
+    def test_registration_failure_unauthorized_request(self):
+        """ Non authenticated user cannot register another user"""
+        # Not an authenticated user
+        self.client.force_authenticate(user=None)
+        request = self.client.post("/registration/", self.registered_system_admin)
+        self.assertEqual(request.status_code,
+                         status.HTTP_401_UNAUTHORIZED)
+
+    def test_registration_failure_method_not_allowed(self):
+        """ User can't access the GET method at this particular endpoint """
+        self.client.force_authenticate(user=self.system_admin)
+        request = self.client.get("/registration/")
+        self.assertEqual(request.status_code,
+                         status.HTTP_405_METHOD_NOT_ALLOWED)
+
+    def test_registration_failure_missing_fields(self):
+        """ Can't register user with missing fields """
+        self.client.force_authenticate(user=self.system_admin)
+        registered_missing_fields = {'user_name': 'missing_fields'}
+        request = self.client.post("/registration/", registered_missing_fields)
+        self.assertEqual(request.status_code, status.HTTP_400_BAD_REQUEST)
+
 
 class OpenRegistrationTestCase(APITestCase):
 
@@ -94,7 +183,6 @@ class OpenRegistrationTestCase(APITestCase):
         response = self.client.get("/open-registration/")
         self.assertEqual(response.status_code,
                          status.HTTP_405_METHOD_NOT_ALLOWED)
-
 
 class LoginTest(APITestCase):
 

--- a/server/user_account/tests.py
+++ b/server/user_account/tests.py
@@ -68,7 +68,7 @@ class AccessAllClientsTestCase(TestCase):
         self.assertEqual(data[1]['role'], user2.role)
 
 
-class RegistrationTestCase(APITestCase):
+class OpenRegistrationTestCase(APITestCase):
 
     def test_registration_success(self):
         """ User was registered correctly """
@@ -79,19 +79,19 @@ class RegistrationTestCase(APITestCase):
                 "last_name": "user",
                 "role": "SA",
                 "is_active": "True"}
-        response = self.client.post("/registration/", data)
+        response = self.client.post("/open-registration/", data)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
     def test_registration_failure(self):
         """ User can't register if missing fields """
         data = {'user_name': 'test_case', "password": "password", "first_name": "test",
                 "last_name": "user", "role": "SA"}
-        response = self.client.post("/registration/", data)
+        response = self.client.post("/open-registration/", data)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_registration_unauthorized_request(self):
         """ User can't access the GET method at this particular endpoint """
-        response = self.client.get("/registration/")
+        response = self.client.get("/open-registration/")
         self.assertEqual(response.status_code,
                          status.HTTP_405_METHOD_NOT_ALLOWED)
 

--- a/server/user_account/urls.py
+++ b/server/user_account/urls.py
@@ -7,7 +7,8 @@ from rest_framework import routers
 from . import views
 
 router = routers.DefaultRouter()
-router.register(r'registration', views.RegistrationView)
+router.register(r'registration', views.RegistrationView, basename='registration')
+router.register(r'open-registration', views.OpenRegistrationView, basename='open_registration')
 
 urlpatterns = [
     path('', include(router.urls)),

--- a/server/user_account/views.py
+++ b/server/user_account/views.py
@@ -33,10 +33,6 @@ class RegistrationView(viewsets.ModelViewSet):
         'user': str(request.user),
         'auth': str(request.auth),
         }
-        # If not authenticated return 401
-        if auth_content['auth'] is None:
-            return Response({'unauthorized': 'Unauthorized request'},
-            status=status.HTTP_401_UNAUTHORIZED)
 
         auth_user = CustomUser.objects.get(user_name=auth_content['user'])
         # TODO: Limit account creation by role
@@ -47,12 +43,7 @@ class RegistrationView(viewsets.ModelViewSet):
         serializer.is_valid(raise_exception=True)
         user = serializer.save()
 
-        # creating token
-        signals.post_save.send(sender=self.__class__,
-                               user=user, request=self.request)
-        token = Token.objects.get(user=user).key
-
-        data = {'user': user.user_name, 'token': token}
+        data = {'user': user.user_name, 'token': auth_content['auth']}
         return Response(data, status=status.HTTP_201_CREATED)
 
 class OpenRegistrationView(viewsets.ModelViewSet):


### PR DESCRIPTION
**Added functionality to create employee accounts of different roles (inventory manager, stock keeper, system admin)** 
- Added the signup component (and form) within the create-members component. The form appears when you click on Create Members from the side menu. 
- The form has been extended to include a drop down menu to select the account role.
- The value from this drop down is required

**Added authenticated registration**
- The registration endpoint has been modified to check for permissions using the IsAuthenticated permission class. This means that nobody can create an account from outside (not logged in) the system (since they are not authenticated yet).
- However there are currently no limitations on creation yet once inside the system (any user can create any other user role)
- Added a TODO for the last point

**Added an open registration endpoint**
- This endpoint is purely for testing/development purposes. It allows us to create accounts from outside (not logged in)  the system. That is the only place where it is called. 
