### PR TITLE
Organization Checking

### DIFF
--- a/server/django_server/permissions.py
+++ b/server/django_server/permissions.py
@@ -57,6 +57,14 @@ class IsInventoryManager(BasePermission):
             if found_false is not None and not found_false:
                 return False
 
+        sent_proper_organization = False
+        for found_true in correct_organization:
+            if found_true:
+                sent_proper_organization = True
+
+        if not sent_proper_organization:
+            return False
+
         if user.role in ['IM', 'SA']:
             return True
         return False

--- a/server/django_server/permissions.py
+++ b/server/django_server/permissions.py
@@ -57,6 +57,7 @@ class IsInventoryManager(BasePermission):
             if found_false is not None and not found_false:
                 return False
 
+        # Used to ensure only the requests accounted for are being made
         sent_proper_organization = False
         for found_true in correct_organization:
             if found_true:
@@ -65,7 +66,7 @@ class IsInventoryManager(BasePermission):
         if not sent_proper_organization:
             return False
 
-        if user.role in ['IM', 'SA']:
+        if user.role in ['IM']:
             return True
         return False
 

--- a/server/organization/tests.py
+++ b/server/organization/tests.py
@@ -67,4 +67,4 @@ class OrganizationTestCase(APITestCase):
         self.client.force_authenticate(user=self.inventory_manager)
         response = self.client.get("/organization/")
         self.assertEqual(response.status_code,
-                         status.HTTP_403_FORBIDDEN)
+                         status.HTTP_200_OK)

--- a/server/organization/tests.py
+++ b/server/organization/tests.py
@@ -67,4 +67,4 @@ class OrganizationTestCase(APITestCase):
         self.client.force_authenticate(user=self.inventory_manager)
         response = self.client.get("/organization/")
         self.assertEqual(response.status_code,
-                         status.HTTP_200_OK)
+                         status.HTTP_403_FORBIDDEN)


### PR DESCRIPTION
Previously within the Inventory manager we had 3 possible checks for the organization, however they were not combined. This now moves these checks into their own functions and then proceeds to check them based on whatever was sent, regardless of the type of request sent. If 2 different organizations are sent or none at all, then the permission will be denied