### PR TITLE
Edit template

### DIFF
--- a/client/src/app/components/audit-template/Template.ts
+++ b/client/src/app/components/audit-template/Template.ts
@@ -1,0 +1,9 @@
+export interface Template {
+  location: any;
+  plant: any;
+  zones: any;
+  aisles: any;
+  bins: any;
+  part_number: any;
+  serial_number: any;
+}

--- a/client/src/app/components/audit-template/audit-template.component.html
+++ b/client/src/app/components/audit-template/audit-template.component.html
@@ -34,7 +34,7 @@
           <mat-icon>create</mat-icon>
           <span>Edit</span>
         </button>
-        <button mat-menu-item>
+        <button mat-menu-item (click)="openDialog(template.template_id, template.title)">
           <mat-icon>delete</mat-icon>
           <span>Delete</span>
         </button>

--- a/client/src/app/components/audit-template/audit-template.component.html
+++ b/client/src/app/components/audit-template/audit-template.component.html
@@ -30,7 +30,7 @@
         </button>
       </div>
       <mat-menu #menu="matMenu" xPosition="after">
-        <button mat-menu-item>
+        <button mat-menu-item [routerLink]="'edit-template/' + template.template_id">
           <mat-icon>create</mat-icon>
           <span>Edit</span>
         </button>

--- a/client/src/app/components/audit-template/audit-template.component.spec.ts
+++ b/client/src/app/components/audit-template/audit-template.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { AuditTemplateComponent } from './audit-template.component';
+import {MatDialogModule} from '@angular/material/dialog';
 
 describe('AuditTemplateComponent', () => {
   let component: AuditTemplateComponent;
@@ -10,7 +11,7 @@ describe('AuditTemplateComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [AuditTemplateComponent],
-      imports: [HttpClientTestingModule, RouterTestingModule],
+      imports: [HttpClientTestingModule, RouterTestingModule, MatDialogModule],
     })
       .compileComponents();
   });

--- a/client/src/app/components/audit-template/audit-template.component.ts
+++ b/client/src/app/components/audit-template/audit-template.component.ts
@@ -39,8 +39,8 @@ export class AuditTemplateComponent implements OnInit {
     );
   }
 
-  openDialog(template_id: string, title: string): void {
-    this.dialogRef = this.dialog.open(DeleteTemplateDialogComponent, {data: {id: template_id, title: title}});
+  openDialog(id: string, title: string): void {
+    this.dialogRef = this.dialog.open(DeleteTemplateDialogComponent, {data: {id, title}});
     this.dialogRef.afterClosed().subscribe(result => {
       if (result) {
         this.auditTemplateService.deleteTemplate(result.id).subscribe( () => {
@@ -53,8 +53,8 @@ export class AuditTemplateComponent implements OnInit {
 }
 
 interface DialogData {
-  title: string
-  id: string
+  title: string;
+  id: string;
 }
 
 @Component({
@@ -67,11 +67,11 @@ export class DeleteTemplateDialogComponent {
     public dialogRef: MatDialogRef<DeleteTemplateDialogComponent>,
     @Optional() @Inject(MAT_DIALOG_DATA) public data: DialogData) { }
 
-  closeDialog() {
+  closeDialog(): void {
     this.dialogRef.close(false);
   }
 
-  deleteTemplate() {
+  deleteTemplate(): void {
     this.dialogRef.close(this.data);
   }
 

--- a/client/src/app/components/audit-template/audit-template.component.ts
+++ b/client/src/app/components/audit-template/audit-template.component.ts
@@ -42,7 +42,11 @@ export class AuditTemplateComponent implements OnInit {
   openDialog(template_id: string, title: string): void {
     this.dialogRef = this.dialog.open(DeleteTemplateDialogComponent, {data: {id: template_id, title: title}});
     this.dialogRef.afterClosed().subscribe(result => {
-      console.log(`Dialog result: ${result}`);
+      if (result) {
+        this.auditTemplateService.deleteTemplate(result.id).subscribe( () => {
+          this.getAuditTemplates();
+        });
+      }
     });
 
   }

--- a/client/src/app/components/audit-template/audit-template.component.ts
+++ b/client/src/app/components/audit-template/audit-template.component.ts
@@ -1,6 +1,7 @@
-import { Component, OnInit } from '@angular/core';
+import {Component, Inject, OnInit, Optional} from '@angular/core';
 import {AuditTemplateService} from '../../services/audit-template.service';
 import {AuthService} from '../../services/auth.service';
+import {MAT_DIALOG_DATA, MatDialog, MatDialogRef} from '@angular/material/dialog';
 
 interface Template {
   author: string;
@@ -16,9 +17,10 @@ interface Template {
 export class AuditTemplateComponent implements OnInit {
   auditTemplates: [Template];
   errorMessage = '';
+  dialogRef: any;
 
   constructor(private auditTemplateService: AuditTemplateService,
-              private authService: AuthService,
+              public dialog: MatDialog
   ) { }
 
   ngOnInit(): void {
@@ -37,6 +39,36 @@ export class AuditTemplateComponent implements OnInit {
     );
   }
 
+  openDialog(template_id: string, title: string): void {
+    this.dialogRef = this.dialog.open(DeleteTemplateDialogComponent, {data: {id: template_id, title: title}});
+    this.dialogRef.afterClosed().subscribe(result => {
+      console.log(`Dialog result: ${result}`);
+    });
 
+  }
+}
+
+interface DialogData {
+  title: string
+  id: string
+}
+
+@Component({
+  selector: 'app-organization-dialog',
+  templateUrl: 'delete-template-dialog.html',
+})
+export class DeleteTemplateDialogComponent {
+
+  constructor(
+    public dialogRef: MatDialogRef<DeleteTemplateDialogComponent>,
+    @Optional() @Inject(MAT_DIALOG_DATA) public data: DialogData) { }
+
+  closeDialog() {
+    this.dialogRef.close(false);
+  }
+
+  deleteTemplate() {
+    this.dialogRef.close(this.data);
+  }
 
 }

--- a/client/src/app/components/audit-template/create-audit-template/create-audit-template.component.html
+++ b/client/src/app/components/audit-template/create-audit-template/create-audit-template.component.html
@@ -26,7 +26,7 @@
             <mat-label>Location</mat-label>
             <mat-form-field appearance="outline">
               <input class="form-control" id="location" type="text" matInput [(ngModel)]="templateValues.location"
-                     placeholder="Location"/>
+                     placeholder="Location" [disabled]="disabled"/>
               <button mat-icon-button matSuffix (click)="addItem('location', templateValues.location)">
                 <mat-icon>add_circle_outline</mat-icon>
               </button>
@@ -37,7 +37,7 @@
             <mat-label>Plant</mat-label>
             <mat-form-field appearance="outline">
               <input class="form-control" id="plant" type="text" matInput [(ngModel)]="templateValues.plant"
-                     placeholder="Plant"/>
+                     placeholder="Plant" [disabled]="disabled"/>
               <button mat-icon-button matSuffix (click)="addItem('plant', templateValues.plant)">
                 <mat-icon>add_circle_outline</mat-icon>
               </button>
@@ -48,7 +48,7 @@
             <mat-label>Zones</mat-label>
             <mat-form-field appearance="outline">
               <input class="form-control" id="zones" type="text" matInput [(ngModel)]="templateValues.zones"
-                     placeholder="Zones"/>
+                     placeholder="Zones" [disabled]="disabled"/>
               <button mat-icon-button matSuffix (click)="addItem('zones', templateValues.zones)">
                 <mat-icon>add_circle_outline</mat-icon>
               </button>
@@ -59,7 +59,7 @@
             <mat-label>Aisles</mat-label>
             <mat-form-field appearance="outline">
               <input class="form-control" id="aisles" type="text" matInput [(ngModel)]="templateValues.aisles"
-                     placeholder="Aisles"/>
+                     placeholder="Aisles" [disabled]="disabled"/>
               <button mat-icon-button matSuffix (click)="addItem('aisles', templateValues.aisles)">
                 <mat-icon>add_circle_outline</mat-icon>
               </button>
@@ -70,7 +70,7 @@
             <mat-label>Bins</mat-label>
             <mat-form-field appearance="outline">
               <input class="form-control" id="bins" type="text" matInput [(ngModel)]="templateValues.bins"
-                     placeholder="Bins"/>
+                     placeholder="Bins" [disabled]="disabled"/>
               <button mat-icon-button matSuffix (click)="addItem('bins', templateValues.bins)">
                 <mat-icon>add_circle_outline</mat-icon>
               </button>
@@ -81,7 +81,7 @@
             <mat-label>Part Number</mat-label>
             <mat-form-field appearance="outline">
               <input class="form-control" id="part_number" type="text" matInput [(ngModel)]="templateValues.part_number"
-                     placeholder="Part Number"/>
+                     placeholder="Part Number" [disabled]="disabled"/>
               <button mat-icon-button matSuffix (click)="addItem('part_number', templateValues.part_number)">
                 <mat-icon>add_circle_outline</mat-icon>
               </button>
@@ -91,8 +91,8 @@
           <div class="form-group">
             <mat-label>Serial Number</mat-label>
             <mat-form-field appearance="outline">
-              <input class="form-control" id="serial_number" type="text" matInput
-                     [(ngModel)]="templateValues.serial_number" placeholder="Serial Number"/>
+              <input class="form-control" id="serial_number" type="text" matInput [disabled]="disabled"
+                     [(ngModel)]="templateValues.serial_number" placeholder="Serial Number" />
               <button mat-icon-button matSuffix
                       (click)="addItem('serial_number', templateValues.serial_number)">
                 <mat-icon>add_circle_outline</mat-icon>
@@ -126,9 +126,13 @@
     </mat-card-content>
   <mat-card-footer>
     <div class="center-aligned">
-      <div class="button-side-by-side">
+      <div class="button-side-by-side" *ngIf="disabled">
+        <button mat-stroked-button id="edit-template-button" class="save-button-bg" (click)="beginEdit()">
+          EDIT</button><!-- if checks throws error then do not send data -->
+      </div>
+      <div class="button-side-by-side" *ngIf="!disabled">
         <button mat-stroked-button id="create-template-button" class="save-button-bg" (click)="submit()">
-          {{templateButtonLabel}}</button><!-- if checks throws error then do not send data -->
+          SAVE</button><!-- if checks throws error then do not send data -->
       </div>
       <div class="button-side-by-side">
         <button mat-stroked-button routerLink="/template">CANCEL</button>

--- a/client/src/app/components/audit-template/create-audit-template/create-audit-template.component.html
+++ b/client/src/app/components/audit-template/create-audit-template/create-audit-template.component.html
@@ -110,7 +110,7 @@
               <mat-chip *ngFor="let value of loc.value"
                         [removable]="true" (removed)="remove(loc.key, value)">
                 {{loc.key.replace('_', ' ') | titlecase}}: {{value}}
-                <mat-icon matChipRemove>cancel</mat-icon>
+                <mat-icon matChipRemove *ngIf="!disabled">cancel</mat-icon>
               </mat-chip>
             </div>
           </mat-chip-list>

--- a/client/src/app/components/audit-template/create-audit-template/create-audit-template.component.ts
+++ b/client/src/app/components/audit-template/create-audit-template/create-audit-template.component.ts
@@ -20,8 +20,8 @@ interface Template {
 export class CreateAuditTemplateComponent implements OnInit {
 
   errorMessage: string;
-  templateButtonLabel = 'SAVE';
   todaysDate = new Date();
+  disabled = false;
 
   title = '';
   description = '';
@@ -109,5 +109,9 @@ export class CreateAuditTemplateComponent implements OnInit {
       this.errorMessage = 'Please give a title to your template.';
     }
 
+  }
+
+  beginEdit(): void {
+    // do nothing
   }
 }

--- a/client/src/app/components/audit-template/create-audit-template/create-audit-template.component.ts
+++ b/client/src/app/components/audit-template/create-audit-template/create-audit-template.component.ts
@@ -110,8 +110,4 @@ export class CreateAuditTemplateComponent implements OnInit {
     }
 
   }
-
-  beginEdit(): void {
-    // do nothing
-  }
 }

--- a/client/src/app/components/audit-template/create-audit-template/create-audit-template.component.ts
+++ b/client/src/app/components/audit-template/create-audit-template/create-audit-template.component.ts
@@ -1,16 +1,8 @@
 import { Component, OnInit } from '@angular/core';
 import {Router} from '@angular/router';
 import {AuditTemplateService} from '../../../services/audit-template.service';
+import { Template } from '../Template';
 
-interface Template {
-  location: any;
-  plant: any;
-  zones: any;
-  aisles: any;
-  bins: any;
-  part_number: any;
-  serial_number: any;
-}
 
 @Component({
   selector: 'app-create-audit-template',

--- a/client/src/app/components/audit-template/delete-template-dialog.html
+++ b/client/src/app/components/audit-template/delete-template-dialog.html
@@ -1,0 +1,10 @@
+<h1 mat-dialog-title>Delete {{data.title}}</h1>
+
+<div mat-dialog-content>
+  Are you sure you want to delete this template?
+</div>
+
+<div mat-dialog-actions>
+  <button mat-stroked-button (click)="deleteTemplate()">Yes</button>
+  <button mat-stroked-button (click)="closeDialog()">Cancel</button>
+</div>

--- a/client/src/app/components/audit-template/edit-audit-template/edit-audit-template.component.spec.ts
+++ b/client/src/app/components/audit-template/edit-audit-template/edit-audit-template.component.spec.ts
@@ -1,0 +1,35 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { FormBuilder } from '@angular/forms';
+import { RouterTestingModule } from '@angular/router/testing';
+import { EditAuditTemplateComponent } from './edit-audit-template.component';
+import { AuditTemplateService } from 'src/app/services/audit-template.service';
+
+describe('AuditTemplateComponent', () => {
+  let component: EditAuditTemplateComponent;
+  let fixture: ComponentFixture<EditAuditTemplateComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [EditAuditTemplateComponent],
+      imports: [HttpClientTestingModule, RouterTestingModule],
+      providers: [
+        FormBuilder,
+        {
+          provide: AuditTemplateService,
+        },
+      ],
+    })
+      .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(EditAuditTemplateComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/client/src/app/components/audit-template/edit-audit-template/edit-audit-template.component.ts
+++ b/client/src/app/components/audit-template/edit-audit-template/edit-audit-template.component.ts
@@ -2,16 +2,8 @@ import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { AuditTemplateService } from '../../../services/audit-template.service';
 import { ActivatedRoute } from '@angular/router';
+import { Template } from '../Template';
 
-interface Template {
-  location: any;
-  plant: any;
-  zones: any;
-  aisles: any;
-  bins: any;
-  part_number: any;
-  serial_number: any;
-}
 
 @Component({
   selector: 'app-edit-audit-template',

--- a/client/src/app/components/audit-template/edit-audit-template/edit-audit-template.component.ts
+++ b/client/src/app/components/audit-template/edit-audit-template/edit-audit-template.component.ts
@@ -21,7 +21,6 @@ interface Template {
 export class EditAuditTemplateComponent implements OnInit {
 
   errorMessage: string;
-  templateButtonLabel = 'SAVE';
   todaysDate = new Date();
 
   title = '';
@@ -37,7 +36,7 @@ export class EditAuditTemplateComponent implements OnInit {
   };
   templateValues: Template;
   id: any;
-  disable: boolean;
+  disabled: boolean;
 
   constructor(
     private router: Router,
@@ -46,6 +45,7 @@ export class EditAuditTemplateComponent implements OnInit {
   ) { }
 
   ngOnInit(): void {
+    this.disabled = false;
     this.templateValues = {
       location: '',
       plant: '',
@@ -80,11 +80,15 @@ export class EditAuditTemplateComponent implements OnInit {
 
   initializeForm(body): void {
     if (body) {
-      this.disable = true;
+      this.disabled = true;
       this.template = body;
     } else {
-      this.disable = false;
+      this.disabled = false;
     }
+  }
+
+  beginEdit(): void {
+    this.disabled = false;
   }
 
   addItem(term, value): void {

--- a/client/src/app/components/audit-template/edit-audit-template/edit-audit-template.component.ts
+++ b/client/src/app/components/audit-template/edit-audit-template/edit-audit-template.component.ts
@@ -126,7 +126,7 @@ export class EditAuditTemplateComponent implements OnInit {
         () => {
           setTimeout(() => {
             // Redirect user back to list of templates
-            this.router.navigate(['template']);
+            window.location.reload();
           }, 1000); // Waiting 1 second before redirecting the user
           this.initializeForm(false);
           this.errorMessage = '';

--- a/client/src/app/components/audit-template/edit-audit-template/edit-audit-template.component.ts
+++ b/client/src/app/components/audit-template/edit-audit-template/edit-audit-template.component.ts
@@ -67,7 +67,7 @@ export class EditAuditTemplateComponent implements OnInit {
   }
 
   formTemplate(temp): any {
-    let createdTemplate: any = {};
+    const createdTemplate: any = {};
     Object.entries(temp).forEach(([key, value]) => {
       if (typeof key === 'string' && typeof value === 'string'
         // checks to make sure that it is only adding keys from the template interface

--- a/client/src/app/components/audit-template/edit-audit-template/edit-audit-template.component.ts
+++ b/client/src/app/components/audit-template/edit-audit-template/edit-audit-template.component.ts
@@ -1,0 +1,143 @@
+import { Component, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
+import { AuditTemplateService } from '../../../services/audit-template.service';
+import { ActivatedRoute } from '@angular/router';
+
+interface Template {
+  location: any;
+  plant: any;
+  zones: any;
+  aisles: any;
+  bins: any;
+  part_number: any;
+  serial_number: any;
+}
+
+@Component({
+  selector: 'app-edit-audit-template',
+  templateUrl: '../create-audit-template/create-audit-template.component.html',
+  styleUrls: ['../create-audit-template/create-audit-template.component.scss']
+})
+export class EditAuditTemplateComponent implements OnInit {
+
+  errorMessage: string;
+  templateButtonLabel = 'SAVE';
+  todaysDate = new Date();
+
+  title = '';
+  description = '';
+  template: Template = {
+    location: [],
+    plant: [],
+    zones: [],
+    aisles: [],
+    bins: [],
+    part_number: [],
+    serial_number: [],
+  };
+  templateValues: Template;
+  id: any;
+  disable: boolean;
+
+  constructor(
+    private router: Router,
+    private auditTemplateService: AuditTemplateService,
+    private activatedRoute: ActivatedRoute,
+  ) { }
+
+  ngOnInit(): void {
+    this.templateValues = {
+      location: '',
+      plant: '',
+      zones: '',
+      aisles: '',
+      bins: '',
+      part_number: '',
+      serial_number: '',
+    };
+    this.activatedRoute.params.subscribe((routeParams) => {
+      this.id = routeParams.ID;
+      this.auditTemplateService.getATemplate(this.id).subscribe((temp) => {
+        this.initializeForm(this.formTemplate(temp));
+        this.title = temp.title;
+        this.description = temp.description;
+        this.id = temp.template_id;
+      });
+    });
+  }
+
+  formTemplate(temp): any {
+    let createdTemplate: any = {};
+    Object.entries(temp).forEach(([key, value]) => {
+      if (typeof key === 'string' && typeof value === 'string'
+        // checks to make sure that it is only adding keys from the template interface
+        && this.templateValues.hasOwnProperty(key)) {
+        createdTemplate[key] = JSON.parse(value.replace(/'/g, '"')); // replace to fix crash on single quote
+      }
+    });
+    return createdTemplate;
+  }
+
+  initializeForm(body): void {
+    if (body) {
+      this.disable = true;
+      this.template = body;
+    } else {
+      this.disable = false;
+    }
+  }
+
+  addItem(term, value): void {
+    // although not obvious, the includes statement here is also necessary for the proper functionality of the remove function
+    if (value !== '' && !this.template[term].includes(value)) {
+      this.template[term].push(value);
+      this.templateValues[term] = '';
+    }
+  }
+
+  remove(term, value): void {
+    const index = this.template[term].indexOf(value);
+
+    if (index >= 0) {
+      this.template[term].splice(index, 1);
+    }
+  }
+
+  submit(): void {
+    const body = {
+      template_id: this.id,
+      title: this.title,
+      location: this.template.location,
+      plant: this.template.plant,
+      zones: this.template.zones,
+      aisles: this.template.aisles,
+      bins: this.template.bins,
+      part_number: this.template.part_number,
+      serial_number: this.template.serial_number,
+      description: this.description,
+    };
+
+    if (this.title !== '') {
+      this.auditTemplateService.updateTemplate(this.id, body).subscribe(
+        () => {
+          setTimeout(() => {
+            // Redirect user back to list of templates
+            this.router.navigate(['template']);
+          }, 1000); // Waiting 1 second before redirecting the user
+          this.initializeForm(false);
+          this.errorMessage = '';
+
+        },
+        (err) => {
+          // if backend returns an error
+          if (err.error) {
+            this.errorMessage = err.error;
+          }
+        }
+      );
+    } else {
+      this.errorMessage = 'Please give a title to your template.';
+    }
+
+  }
+}

--- a/client/src/app/modules/alta-main-routing/alta-main-routing.module.ts
+++ b/client/src/app/modules/alta-main-routing/alta-main-routing.module.ts
@@ -10,6 +10,7 @@ import { CreateMemberComponent } from '../../components/create-member/create-mem
 import { ManageInventoryItemsComponent } from 'src/app/components/manage-inventory-items/manage-inventory-items.component';
 import { CreateAuditTemplateComponent } from '../../components/audit-template/create-audit-template/create-audit-template.component';
 import { AuditTemplateComponent } from '../../components/audit-template/audit-template.component';
+import { EditAuditTemplateComponent } from 'src/app/components/audit-template/edit-audit-template/edit-audit-template.component';
 
 export const routes: Routes = [
   {
@@ -37,6 +38,9 @@ export const routes: Routes = [
           },
           {
             path: 'create-template', component: CreateAuditTemplateComponent
+          },
+          {
+            path: 'edit-template/:ID', component: EditAuditTemplateComponent
           }
         ]},
     ],

--- a/client/src/app/modules/alta-main/alta-main.module.ts
+++ b/client/src/app/modules/alta-main/alta-main.module.ts
@@ -23,7 +23,7 @@ import { MatDialogModule } from '@angular/material/dialog';
 import { ManageInventoryItemsComponent } from '../../components/manage-inventory-items/manage-inventory-items.component';
 import { CreateAuditTemplateComponent } from '../../components/audit-template/create-audit-template/create-audit-template.component';
 import { EditAuditTemplateComponent } from '../../components/audit-template/edit-audit-template/edit-audit-template.component';
-import { AuditTemplateComponent } from '../../components/audit-template/audit-template.component';
+import { AuditTemplateComponent, DeleteTemplateDialogComponent } from '../../components/audit-template/audit-template.component';
 import {FlexLayoutModule} from '@angular/flex-layout';
 import {MAT_DATE_LOCALE, MatChipsModule, MatDatepickerModule, MatNativeDateModule} from '@angular/material';
 
@@ -39,6 +39,7 @@ import {MAT_DATE_LOCALE, MatChipsModule, MatDatepickerModule, MatNativeDateModul
     OrganizationDialogComponent,
     ManageInventoryItemsComponent,
     CreateAuditTemplateComponent,
+    DeleteTemplateDialogComponent,
     AuditTemplateComponent,
     EditAuditTemplateComponent
   ],

--- a/client/src/app/modules/alta-main/alta-main.module.ts
+++ b/client/src/app/modules/alta-main/alta-main.module.ts
@@ -22,6 +22,7 @@ import { MatMenuModule } from '@angular/material/menu';
 import { MatDialogModule } from '@angular/material/dialog';
 import { ManageInventoryItemsComponent } from '../../components/manage-inventory-items/manage-inventory-items.component';
 import { CreateAuditTemplateComponent } from '../../components/audit-template/create-audit-template/create-audit-template.component';
+import { EditAuditTemplateComponent } from '../../components/audit-template/edit-audit-template/edit-audit-template.component';
 import { AuditTemplateComponent } from '../../components/audit-template/audit-template.component';
 import {FlexLayoutModule} from '@angular/flex-layout';
 import {MAT_DATE_LOCALE, MatChipsModule, MatDatepickerModule, MatNativeDateModule} from '@angular/material';
@@ -39,6 +40,7 @@ import {MAT_DATE_LOCALE, MatChipsModule, MatDatepickerModule, MatNativeDateModul
     ManageInventoryItemsComponent,
     CreateAuditTemplateComponent,
     AuditTemplateComponent,
+    EditAuditTemplateComponent
   ],
 
   imports: [

--- a/client/src/app/services/audit-template.service.ts
+++ b/client/src/app/services/audit-template.service.ts
@@ -25,4 +25,12 @@ export class AuditTemplateService {
       return this.http.get(`${BASEURL}/template/`, {params: {organization: this.orgId}});
   }
 
+  getATemplate(id): Observable<any> {
+    return this.http.get(`${BASEURL}/template/${id}/`);
+  }
+
+  updateTemplate(id, template): Observable<any> {
+    return this.http.patch(`${BASEURL}/template/${id}/`, template);
+  }
+
 }

--- a/client/src/app/services/audit-template.service.ts
+++ b/client/src/app/services/audit-template.service.ts
@@ -33,4 +33,8 @@ export class AuditTemplateService {
     return this.http.patch(`${BASEURL}/template/${id}/`, template);
   }
 
+  deleteTemplate(id): Observable<any> {
+    return this.http.delete(`${BASEURL}/template/${id}/`)
+  }
+
 }

--- a/client/src/app/services/audit-template.service.ts
+++ b/client/src/app/services/audit-template.service.ts
@@ -34,7 +34,7 @@ export class AuditTemplateService {
   }
 
   deleteTemplate(id): Observable<any> {
-    return this.http.delete(`${BASEURL}/template/${id}/`)
+    return this.http.delete(`${BASEURL}/template/${id}/`);
   }
 
 }

--- a/server/audit_template/permissions.py
+++ b/server/audit_template/permissions.py
@@ -5,7 +5,8 @@ from .models import AuditTemplate
 class IsInventoryManagerTemplate(IsInventoryManager):
 
     def has_permission(self, request, view):
-        if request.parser_context['kwargs'] is not None and 'pk' in request.parser_context['kwargs']:
+        if request.parser_context['kwargs'] is not None \
+                and 'pk' in request.parser_context['kwargs']:
             temp = AuditTemplate.objects.get(template_id=request.parser_context['kwargs']['pk'])
             return temp.organization == request.user.organization and request.user.role == 'IM'
         return super().has_permission(request, view)

--- a/server/audit_template/permissions.py
+++ b/server/audit_template/permissions.py
@@ -1,0 +1,11 @@
+from user_account.permissions import IsInventoryManager
+from .models import AuditTemplate
+
+
+class IsInventoryManagerTemplate(IsInventoryManager):
+
+    def has_permission(self, request, view):
+        if request.parser_context['kwargs'] is not None and 'pk' in request.parser_context['kwargs']:
+            temp = AuditTemplate.objects.get(template_id=request.parser_context['kwargs']['pk'])
+            return temp.organization == request.user.organization and request.user.role == 'IM'
+        return super().has_permission(request, view)

--- a/server/audit_template/tests.py
+++ b/server/audit_template/tests.py
@@ -1,6 +1,8 @@
 from rest_framework.test import APITestCase, APIClient
 from rest_framework import status
 from user_account.models import CustomUser
+import json
+
 
 class AuditTemplateTestCase(APITestCase):
     fixtures = ["users.json", "organizations.json", "audit_template.json"]
@@ -52,3 +54,57 @@ class AuditTemplateTestCase(APITestCase):
         for template in req.data:
             self.assertEqual(template["organization"], self.user1.organization_id)
         self.assertGreater(len(req.data), 0)
+
+        failed_req = self.client.get(f'{self.url}?organization=1234567890')
+        self.assertEqual(failed_req.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_get_a_template(self):
+        """
+        Testing get method to make sure permissions work along with the functionality
+        """
+        self.client.force_authenticate(user=self.user1)
+        req = self.client.get(f'{self.url}8/')
+        self.assertEqual(req.status_code, status.HTTP_200_OK)
+        self.assertEqual(req.data["title"], "fewqfwq")
+
+        failed_req = self.client.get(f'{self.url}7/')
+        self.assertEqual(failed_req.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_patch_template(self):
+        """
+        Testing patch method to make sure it functions properly and permissions work as intended
+        """
+
+        # getting a template to test on from fixture
+        self.client.force_authenticate(user=self.user1)
+        req = self.client.get(f'{self.url}8/')
+        data = req.data
+
+        # parsing data into python object because json fields return strings
+        data = {k: json.loads(v.replace("\'", "\"")) if isinstance(v, str) and '[' in v else v for k, v in data.items()}
+        self.assertEqual(data['plant'], [])
+
+        # creating and testing successful patch
+        data['plant'].append("new plant")
+        patch_req = self.client.patch(f'{self.url}8/', data, format='json')
+        self.assertEqual(patch_req.status_code, status.HTTP_200_OK)
+        new_template = self.client.get(f'{self.url}8/')
+        self.assertEqual(new_template.data['plant'], "['new plant']")
+
+        # ensuring users can't patch templates for which they are not authorized
+        failed_patch = self.client.patch(f'{self.url}7/', data, format='json')
+        self.assertEqual(failed_patch.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_delete(self):
+        """
+        Testing delete method to make sure it functions properly and permissions work as intended
+        """
+
+        # testing deletion successful path
+        self.client.force_authenticate(user=self.user1)
+        successful_req = self.client.delete(f'{self.url}8/')
+        self.assertEqual(successful_req.status_code, status.HTTP_204_NO_CONTENT)
+
+        # ensuring users can't delete templates from other organizations
+        failed_delete = self.client.delete(f'{self.url}7/')
+        self.assertEqual(failed_delete.status_code, status.HTTP_403_FORBIDDEN)

--- a/server/audit_template/views.py
+++ b/server/audit_template/views.py
@@ -34,7 +34,7 @@ class AuditTemplateViewSet(viewsets.ModelViewSet):
 
         return Response(status=status.HTTP_201_CREATED)
 
-    def list(self, request, *args, **kwargs):
+    def list(self, request):
         queryset = self.filter_queryset(self.get_queryset()).filter(
                 organization_id=self.request.GET.get("organization", ''))
 

--- a/server/audit_template/views.py
+++ b/server/audit_template/views.py
@@ -20,13 +20,6 @@ class AuditTemplateViewSet(viewsets.ModelViewSet):
     permission_classes = [IsAuthenticated, IsInventoryManagerTemplate | IsSystemAdmin]
     http_method_names = ['post', 'get', 'patch', 'delete']
 
-    def get_queryset(self):
-        if self.action == 'list':
-            return AuditTemplate.objects.filter(
-                organization_id=self.request.GET.get("organization", ''))
-        elif self.action == 'retrieve' or self.action == 'partial_update' or self.action == 'destroy':
-            return AuditTemplate.objects.all()
-
     def create(self, request, *args, **kwargs):
         data = request.data
         user = request.user
@@ -40,3 +33,10 @@ class AuditTemplateViewSet(viewsets.ModelViewSet):
         serializer.save()
 
         return Response(status=status.HTTP_201_CREATED)
+
+    def list(self, request, *args, **kwargs):
+        queryset = self.filter_queryset(self.get_queryset()).filter(
+                organization_id=self.request.GET.get("organization", ''))
+
+        serializer = self.get_serializer(queryset, many=True)
+        return Response(serializer.data)

--- a/server/audit_template/views.py
+++ b/server/audit_template/views.py
@@ -18,13 +18,13 @@ class AuditTemplateViewSet(viewsets.ModelViewSet):
     queryset = AuditTemplate.objects.all()
     serializer_class = AuditTemplateSerializer
     permission_classes = [IsAuthenticated, IsInventoryManagerTemplate | IsSystemAdmin]
-    http_method_names = ['post', 'get', 'patch', 'partial_update']
+    http_method_names = ['post', 'get', 'patch', 'delete']
 
     def get_queryset(self):
         if self.action == 'list':
             return AuditTemplate.objects.filter(
                 organization_id=self.request.GET.get("organization", ''))
-        elif self.action == 'retrieve' or self.action == 'partial_update':
+        elif self.action == 'retrieve' or self.action == 'partial_update' or self.action == 'destroy':
             return AuditTemplate.objects.all()
 
     def create(self, request, *args, **kwargs):

--- a/server/audit_template/views.py
+++ b/server/audit_template/views.py
@@ -4,7 +4,8 @@ from rest_framework import viewsets, status
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
-from user_account.permissions import IsSystemAdmin, IsInventoryManager
+from user_account.permissions import IsSystemAdmin
+from .permissions import IsInventoryManagerTemplate
 from .serializers import AuditTemplateSerializer
 from .models import AuditTemplate
 
@@ -16,18 +17,8 @@ class AuditTemplateViewSet(viewsets.ModelViewSet):
 
     queryset = AuditTemplate.objects.all()
     serializer_class = AuditTemplateSerializer
-    #permission_classes = [IsAuthenticated, IsInventoryManager | IsSystemAdmin]
+    permission_classes = [IsAuthenticated, IsInventoryManagerTemplate | IsSystemAdmin]
     http_method_names = ['post', 'get', 'patch', 'partial_update']
-
-    def get_permissions(self):
-        request = self.request
-        if request.parser_context['kwargs'] is not None and 'pk'\
-                in request.parser_context['kwargs']:
-            # todo: vulnerability here, need to fix
-            perm = [IsAuthenticated]
-        else:
-            perm = [IsAuthenticated, (IsInventoryManager | IsSystemAdmin)]
-        return [permission() for permission in perm]
 
     def get_queryset(self):
         if self.action == 'list':

--- a/server/organization/fixtures/organizations.json
+++ b/server/organization/fixtures/organizations.json
@@ -1,12 +1,22 @@
 [
-{
-    "model": "organization.organization",
-    "pk": 1,
-    "fields": {
-        "org_name": "test",
-        "address": "Florida",
-        "status": true,
-        "inventory_items_refresh_job": 1
+    {
+        "model": "organization.organization",
+        "pk": 1,
+        "fields": {
+            "org_name": "test",
+            "address": "Florida",
+            "status": true,
+            "inventory_items_refresh_job": 1
+        }
+    },
+    {
+        "model": "organization.organization",
+        "pk": 3,
+        "fields": {
+            "org_name": "test2",
+            "address": "Florida2",
+            "status": true,
+            "inventory_items_refresh_job": 1
+        }
     }
-}
 ]


### PR DESCRIPTION
This issue aims to complete the functionality for user story 3.4 (#52).

The intention is to allow users to edit created templates for their own organization (including deletion).

The permissions are also intended to be set up to prevent users from modifying templates and retrieving templates from other organizations.