### PR TITLE
Issue #224 Side navigation item highlight fix

### DIFF
--- a/client/e2e/src/backend-service.e2e-spec.ts
+++ b/client/e2e/src/backend-service.e2e-spec.ts
@@ -1,5 +1,5 @@
 import { env } from '../../src/environments/environment';
-import {IncomingMessage} from "http";
+import { IncomingMessage } from 'http';
 const http = require('http');
 
 describe('Test Backend Connection', () => {

--- a/client/src/app/components/assign-stock-keepers/assign-stock-keepers.component.ts
+++ b/client/src/app/components/assign-stock-keepers/assign-stock-keepers.component.ts
@@ -113,7 +113,7 @@ export class AssignStockKeepersComponent implements OnInit {
         this.skToAssign = [];
         setTimeout(() => {
           // Redirect user to component dashboard
-          this.router.navigate(['designate-sk']);
+          this.router.navigate(['audits/assign-sk/designate-sk']);
         }, 1000); // Waiting 1 second before redirecting the user
       },
       (err) => {

--- a/client/src/app/components/manage-inventory-items/manage-inventory-items.component.ts
+++ b/client/src/app/components/manage-inventory-items/manage-inventory-items.component.ts
@@ -230,7 +230,7 @@ export class ManageInventoryItemsComponent implements OnInit {
         this.inventoryItemToAudit = [];
         setTimeout(() => {
           // Redirect user to component assign-stock-keepers
-          this.router.navigate(['assign-sk']);
+          this.router.navigate(['audits/assign-sk']);
         }, 1000); // Waiting 1 second before redirecting the user
       },
       (err) => {

--- a/client/src/app/components/sidenav/sidenav.component.ts
+++ b/client/src/app/components/sidenav/sidenav.component.ts
@@ -95,23 +95,17 @@ export class SideNavComponent implements OnInit {
       if (this.options === SystemNavListings) {
         // @ts-ignore
         // TODO: should there be a default url if routes[] is undefined?
-        // NOTICE: url changes types from string to Route
-        url = routes[0].children[4]; // '/sa-modify-members';
+        url = routes[0].children[4].path; // '/sa-modify-members';
       }
       else if (this.options === OrganizationNavListings) {
         // @ts-ignore
-        // TODO: should there be a default url if routes[] is undefined?
-        // NOTICE: url changes types from string to Route
-        url = routes[0].children[3]; // '/modify-members';
+        url = routes[0].children[3].path; // '/modify-members';
       }
-
     }
 
-
     this.options.forEach(navOption => {
-      if ('/' + navOption.routerLink === url) {
+      if (url.includes(navOption.routerLink)) {
         this.selectedOption = navOption;
-        return;
       }
     });
   }

--- a/client/src/app/components/sidenav/sidenav.component.ts
+++ b/client/src/app/components/sidenav/sidenav.component.ts
@@ -103,6 +103,10 @@ export class SideNavComponent implements OnInit {
       }
     }
 
+    if (url.includes('modify-members') && this.options === SystemNavListings){
+        url = 'sa-modify-members';
+    }
+
     this.options.forEach(navOption => {
       if (url.includes(navOption.routerLink)) {
         this.selectedOption = navOption;

--- a/client/src/app/modules/alta-main-routing/alta-main-routing.module.ts
+++ b/client/src/app/modules/alta-main-routing/alta-main-routing.module.ts
@@ -47,8 +47,20 @@ export const routes: Routes = [
       { path: 'settings', component: EmployeeSettingsComponent },
       { path: 'sa-settings', component: EmployeeSettingsComponent },
       { path: 'manage-items', component: ManageInventoryItemsComponent },
-      { path: 'assign-sk', component: AssignStockKeepersComponent },
-      { path: 'designate-sk', component: ManageStockKeepersDesignationComponent},
+      { path: 'audits', children: [
+        {
+          path: '', component: ManageInventoryItemsComponent
+        },
+        {
+          path: 'assign-sk', children: [
+            {
+              path: '', component: AssignStockKeepersComponent
+            },
+            {
+              path: 'designate-sk', component: ManageStockKeepersDesignationComponent
+            }
+          ]},
+      ]},
       { path: 'template', children: [
           {
             path: '', component: AuditTemplateComponent


### PR DESCRIPTION
#### Fix for #224
The issue was related to incorrect types being used. We need to use the path (string) not the router object. I also changed the condition to use includes and not direct equals.

This fixed the issue however the new assign and designate sk pages weren't linked to any parent routes from the side nav so no item would be highlighted when accessing those particular pages.
I decided to link them to the audits parent URL like this `audits/assing-sk/designate-sk/`
The `Audits` menu item redirected nowhere so it now routes to the `Inventory Items` page temporarily.