### PR TITLE
Fix item refresh im bug

### DIFF
--- a/client/src/app/components/employees/employee-view/create-employee/create-employee.component.ts
+++ b/client/src/app/components/employees/employee-view/create-employee/create-employee.component.ts
@@ -70,7 +70,7 @@ export class CreateEmployeeComponent extends EmployeeView implements OnInit {
 
     const body = {
       ...base,
-      role: this.employeeForm.value.role?.abbrev ? this.employeeForm.value.role.abbrev : 'SK',
+      role: this.employeeForm.value.role?.abbrev ? this.employeeForm.value.role.abbrev : 'SA',
       is_active: 'true',
       password: this.employeeForm.value.password,
       // parse the organization as an int to be sent to the backend

--- a/server/organization/views.py
+++ b/server/organization/views.py
@@ -53,7 +53,7 @@ class ModifyOrganizationInventoryItemsDataUpdate(generics.GenericAPIView):
             organization = Organization.objects.get(org_id=org_id)
             organization.inventory_items_refresh_job = new_job_timing
             organization.save()
-            start_new_job(org_id, new_job_timing)
+            start_new_job(str(org_id), new_job_timing)
             return Response({'detail': 'Time has been updated'}, status=status.HTTP_200_OK)
 
         except Organization.DoesNotExist:

--- a/server/organization/views.py
+++ b/server/organization/views.py
@@ -43,12 +43,7 @@ class ModifyOrganizationInventoryItemsDataUpdate(generics.GenericAPIView):
 
     # Note: if other methods are added here, keep in mind that the permissions will need to change
     def get_permissions(self):
-        permission_classes = []
-        if IsInventoryManager.has_permission(self, self.request, ModifyOrganizationInventoryItemsDataUpdate) and \
-                HasSameOrgInBody.has_permission(self, self.request, ModifyOrganizationInventoryItemsDataUpdate):
-            permission_class = [IsAuthenticated]
-        else:
-            permission_classes = [IsAuthenticated, IsSystemAdmin]
+        permission_classes = PermissionFactory(self.request).get_general_permissions([])
         return [permission() for permission in permission_classes]
 
     def post(self, request):

--- a/server/organization/views.py
+++ b/server/organization/views.py
@@ -42,7 +42,14 @@ class ModifyOrganizationInventoryItemsDataUpdate(generics.GenericAPIView):
     """
 
     # Note: if other methods are added here, keep in mind that the permissions will need to change
-    permission_classes = [IsAuthenticated, IsSystemAdmin | (IsInventoryManager, HasSameOrgInBody)]
+    def get_permissions(self):
+        permission_classes = []
+        if IsInventoryManager.has_permission(self, self.request, ModifyOrganizationInventoryItemsDataUpdate) and \
+                HasSameOrgInBody.has_permission(self, self.request, ModifyOrganizationInventoryItemsDataUpdate):
+            permission_class = [IsAuthenticated]
+        else:
+            permission_classes = [IsAuthenticated, IsSystemAdmin]
+        return [permission() for permission in permission_classes]
 
     def post(self, request):
         data = request.data

--- a/server/user_account/permissions.py
+++ b/server/user_account/permissions.py
@@ -69,7 +69,7 @@ class HasSameOrgInBody(BasePermission):
 
     def has_permission(self, request, view):
         if 'organization' in request.data:
-            return request.user.organization_id == request.data['organization']
+            return str(request.user.organization_id) == str(request.data['organization'])
         return True
 
 


### PR DESCRIPTION
Previously, when an IM attempted to update the job refresh time, they were unable to achieve this due to a coherency error where the permission and the view required 2 different data types, this has now been fixed