### PR TITLE
[ALTA-3.9] Auto-assign bins to stock-keepers

### DIFF
--- a/client/src/app/components/manage-stock-keepers-designation/manage-stock-keepers-designation.component.html
+++ b/client/src/app/components/manage-stock-keepers-designation/manage-stock-keepers-designation.component.html
@@ -3,6 +3,7 @@
     <div id="top-div">
       <button mat-button class="top-buttons" (click)="allExpandState=true">Expand All </button>
       <button mat-button class="top-buttons" (click)="allExpandState=false">Collapse All </button>
+      <button mat-button class="top-buttons auto-assign" (click)="autoAssign()">Auto Assign</button>
     </div>
   </mat-card>
   <br>
@@ -67,7 +68,7 @@
   <div class="bottom-buttons">
       <button mat-stroked-button  id="goback" class="bottom-goback"
             (click)="goBackAssignSK()">Go Back</button>
-    <button mat-stroked-button  id="discard" class="bottom-discard" 
+    <button mat-stroked-button  id="discard" class="bottom-discard"
             (click)="openDialogWithRef(discardDialog)">Discard</button>
     <button mat-stroked-button  id="assign" class="bottom-assign"
             [disabled]="checkDisableButton(binToSks)"

--- a/client/src/app/components/manage-stock-keepers-designation/manage-stock-keepers-designation.component.scss
+++ b/client/src/app/components/manage-stock-keepers-designation/manage-stock-keepers-designation.component.scss
@@ -42,6 +42,11 @@
   border: 1px solid #2196F3 !important;
 }
 
+.auto-assign:hover {
+  background-color: #4ececa;
+  color: white;
+}
+
 button.bottom-goback {
   position: absolute;
   left: -438px;

--- a/client/src/app/components/manage-stock-keepers-designation/manage-stock-keepers-designation.component.ts
+++ b/client/src/app/components/manage-stock-keepers-designation/manage-stock-keepers-designation.component.ts
@@ -39,6 +39,35 @@ export class ManageStockKeepersDesignationComponent implements OnInit {
       });
   }
 
+  autoAssign(): void {
+    console.table("BEFORE Original: ", this.locationsWithBinsAndSKs)
+    console.table("BEFORE After: ", this.binToSks)
+
+    let tester = "";
+    let associatedItems = [];
+    let indexToRemove = "";
+
+    this.binToSks.forEach(index => {
+
+      tester = this.locationsWithBinsAndSKs.find(obj => obj.Location === index.sk_location)
+
+      tester.bins.forEach(bin => {
+        associatedItems = this.getAssociatedItemsGivenBin(index.sk_location, [bin]);
+        const holdIds = associatedItems.map(item => item._id);
+        index.bins.push(bin);
+        index.item_ids = holdIds;
+
+        let holder = this.locationsWithBinsAndSKs.find(obj => obj.Location === index.sk_location);
+        indexToRemove = holder.bins.findIndex(obj => obj === bin);
+        holder.bins.splice(indexToRemove, 1);
+      });
+    });
+
+    console.log(indexToRemove)
+    console.table("AFTER Original: ", this.locationsWithBinsAndSKs)
+    console.table("AFTER After: ", this.binToSks)
+  }
+
   populateBinsAndSKs(selectedItems: Item[], assignedSks: SKUser[]): void {
     /* TODO: look into performance impact of:
     * 1. returning a large amount of items

--- a/client/src/app/components/manage-stock-keepers-designation/manage-stock-keepers-designation.component.ts
+++ b/client/src/app/components/manage-stock-keepers-designation/manage-stock-keepers-designation.component.ts
@@ -40,32 +40,25 @@ export class ManageStockKeepersDesignationComponent implements OnInit {
   }
 
   autoAssign(): void {
-    console.table("BEFORE Original: ", this.locationsWithBinsAndSKs)
-    console.table("BEFORE After: ", this.binToSks)
-
-    let tester = "";
+    let sksOfCurrentLocation = [];
     let associatedItems = [];
-    let indexToRemove = "";
 
-    this.binToSks.forEach(index => {
+    this.locationsWithBinsAndSKs.forEach(index => {
+      let currentSK = 0;
+      index.bins.forEach(bin => {
+        associatedItems = this.getAssociatedItemsGivenBin(index.Location, [bin]);
+        const associatedItemsIds = associatedItems.map(item => item._id);
 
-      tester = this.locationsWithBinsAndSKs.find(obj => obj.Location === index.sk_location)
+        sksOfCurrentLocation = this.binToSks.filter(obj => obj.sk_location === index.Location)
+        let currentToAssign = currentSK % sksOfCurrentLocation.length;
 
-      tester.bins.forEach(bin => {
-        associatedItems = this.getAssociatedItemsGivenBin(index.sk_location, [bin]);
-        const holdIds = associatedItems.map(item => item._id);
-        index.bins.push(bin);
-        index.item_ids = holdIds;
+        sksOfCurrentLocation[currentToAssign].bins.push(bin);
+        sksOfCurrentLocation[currentToAssign].item_ids = associatedItemsIds;
 
-        let holder = this.locationsWithBinsAndSKs.find(obj => obj.Location === index.sk_location);
-        indexToRemove = holder.bins.findIndex(obj => obj === bin);
-        holder.bins.splice(indexToRemove, 1);
+        currentSK++;
       });
+      index.bins = [];
     });
-
-    console.log(indexToRemove)
-    console.table("AFTER Original: ", this.locationsWithBinsAndSKs)
-    console.table("AFTER After: ", this.binToSks)
   }
 
   populateBinsAndSKs(selectedItems: Item[], assignedSks: SKUser[]): void {

--- a/client/src/app/components/manage-stock-keepers-designation/manage-stock-keepers-designation.component.ts
+++ b/client/src/app/components/manage-stock-keepers-designation/manage-stock-keepers-designation.component.ts
@@ -49,8 +49,8 @@ export class ManageStockKeepersDesignationComponent implements OnInit {
         associatedItems = this.getAssociatedItemsGivenBin(index.Location, [bin]);
         const associatedItemsIds = associatedItems.map(item => item._id);
 
-        sksOfCurrentLocation = this.binToSks.filter(obj => obj.sk_location === index.Location)
-        let currentToAssign = currentSK % sksOfCurrentLocation.length;
+        sksOfCurrentLocation = this.binToSks.filter(obj => obj.sk_location === index.Location);
+        const currentToAssign = currentSK % sksOfCurrentLocation.length;
 
         sksOfCurrentLocation[currentToAssign].bins.push(bin);
         sksOfCurrentLocation[currentToAssign].item_ids = associatedItemsIds;

--- a/client/src/app/components/manage-stock-keepers-designation/manage-stock-keepers-designation.component.ts
+++ b/client/src/app/components/manage-stock-keepers-designation/manage-stock-keepers-designation.component.ts
@@ -45,7 +45,7 @@ export class ManageStockKeepersDesignationComponent implements OnInit {
 
     this.locationsWithBinsAndSKs.forEach(index => {
       let currentSK = 0;
-      index.bins.forEach(bin => {
+      index.bins.forEach((bin: any) => {
         associatedItems = this.getAssociatedItemsGivenBin(index.Location, [bin]);
         const associatedItemsIds = associatedItems.map(item => item._id);
 


### PR DESCRIPTION
### Related issue: ALTA-3.9 (#193)

Implemented functionality:

- Once an audit is initiated through the _Inventory Items_ page and the user has selected the corresponding stock-keepers, they will be able to auto-assign the selected bins to the assigned stock-keepers.
- Assignment is executed in a Round Robin fashion



