### PR TITLE
Autocomplete search results for the Audit Templates Fields

### DIFF
--- a/client/src/app/app.module.ts
+++ b/client/src/app/app.module.ts
@@ -12,6 +12,7 @@ import { TokenInterceptor } from './services/authentication/token-interceptor';
 import { CookieService } from 'ngx-cookie-service';
 import { MatModule } from './modules/material/material-module';
 import { FlexLayoutModule } from '@angular/flex-layout';
+import { ReactiveFormsModule } from '@angular/forms';
 
 @NgModule({
   declarations: [
@@ -27,6 +28,7 @@ import { FlexLayoutModule } from '@angular/flex-layout';
     HttpClientModule,
     MatModule,
     FlexLayoutModule,
+    ReactiveFormsModule
   ],
   providers: [
     CookieService, // To manage cookie in frontend

--- a/client/src/app/components/assign-stock-keepers/assign-stock-keepers.component.ts
+++ b/client/src/app/components/assign-stock-keepers/assign-stock-keepers.component.ts
@@ -124,7 +124,7 @@ export class AssignStockKeepersComponent implements OnInit {
       (data) => {
         this.skToAssign = [];
         this.manageAuditsService.createAuditAssignments(this.assignments).subscribe(
-          _=> {
+          _ => {
             this.assignments = [];
           },
           (err) => {

--- a/client/src/app/components/audit-template/audit-template-view/audit-template-view.component.html
+++ b/client/src/app/components/audit-template/audit-template-view/audit-template-view.component.html
@@ -4,7 +4,7 @@
 
   <div class="form-group">
     <mat-form-field appearance="outline" class="half-width">
-      <input class="form-control" id="title" type="text" matInput [(ngModel)]="title" placeholder="Template title"/>
+      <input class="form-control" id="title" type="text" matInput [(ngModel)]="title" placeholder="Template title" />
 
     </mat-form-field>
     <mat-error class="error">
@@ -22,82 +22,138 @@
 
         <!-- LEFT SIDE -->
 
-        <div class="form-group" *ngIf="templateValues.location || templateValues.location === ''">
-          <mat-label>Location</mat-label>
-          <mat-form-field appearance="outline">
-            <input class="form-control" id="location" type="text" matInput [(ngModel)]="templateValues.location"
-                   placeholder="Location" [disabled]="disabled"/>
-            <button mat-icon-button matSuffix (click)="addItem('location', templateValues.location)" [disabled]="disabled">
-              <mat-icon>add_circle_outline</mat-icon>
-            </button>
-          </mat-form-field>
-        </div>
+        <div [formGroup]="autocompleteFormGroup">
+          <div class="form-group" *ngIf="templateValues.location || templateValues.location === ''">
+            <mat-label>Location</mat-label>
+            <mat-form-field appearance="outline">
+              <input class="form-control" id="location" type="text" matInput [(ngModel)]="templateValues.location"
+                placeholder="Location" [disabled]="disabled" [matAutocomplete]="auto" formControlName="location" />
 
-        <div class="form-group" *ngIf="templateValues.plant  || templateValues.plant === ''">
-          <mat-label>Plant</mat-label>
-          <mat-form-field appearance="outline">
-            <input class="form-control" id="plant" type="text" matInput [(ngModel)]="templateValues.plant"
-                   placeholder="Plant" [disabled]="disabled"/>
-            <button mat-icon-button matSuffix (click)="addItem('plant', templateValues.plant)" [disabled]="disabled">
-              <mat-icon>add_circle_outline</mat-icon>
-            </button>
-          </mat-form-field>
-        </div>
+              <mat-autocomplete #auto="matAutocomplete">
+                <mat-option *ngFor="let result of filterFieldResults" [value]="result">
+                  {{result}}
+                </mat-option>
+              </mat-autocomplete>
 
-        <div class="form-group" *ngIf="templateValues.zones  || templateValues.zones === ''">
-          <mat-label>Zones</mat-label>
-          <mat-form-field appearance="outline">
-            <input class="form-control" id="zones" type="text" matInput [(ngModel)]="templateValues.zones"
-                   placeholder="Zones" [disabled]="disabled"/>
-            <button mat-icon-button matSuffix (click)="addItem('zones', templateValues.zones)" [disabled]="disabled">
-              <mat-icon>add_circle_outline</mat-icon>
-            </button>
-          </mat-form-field>
-        </div>
+              <button mat-icon-button matSuffix (click)="addItem('location', templateValues.location)"
+                [disabled]="disabled">
+                <mat-icon>add_circle_outline</mat-icon>
+              </button>
+            </mat-form-field>
+          </div>
 
-        <div class="form-group" *ngIf="templateValues.aisles  || templateValues.aisles === ''">
-          <mat-label>Aisles</mat-label>
-          <mat-form-field appearance="outline">
-            <input class="form-control" id="aisles" type="text" matInput [(ngModel)]="templateValues.aisles"
-                   placeholder="Aisles" [disabled]="disabled"/>
-            <button mat-icon-button matSuffix (click)="addItem('aisles', templateValues.aisles)" [disabled]="disabled">
-              <mat-icon>add_circle_outline</mat-icon>
-            </button>
-          </mat-form-field>
-        </div>
+          <div class="form-group" *ngIf="templateValues.plant  || templateValues.plant === ''">
+            <mat-label>Plant</mat-label>
+            <mat-form-field appearance="outline">
+              <input class="form-control" id="plant" type="text" matInput [(ngModel)]="templateValues.plant"
+                placeholder="Plant" [disabled]="disabled" [matAutocomplete]="auto" formControlName="plant" />
 
-        <div class="form-group" *ngIf="templateValues.bins  || templateValues.bins === ''">
-          <mat-label>Bins</mat-label>
-          <mat-form-field appearance="outline">
-            <input class="form-control" id="bins" type="text" matInput [(ngModel)]="templateValues.bins"
-                   placeholder="Bins" [disabled]="disabled"/>
-            <button mat-icon-button matSuffix (click)="addItem('bins', templateValues.bins)" [disabled]="disabled">
-              <mat-icon>add_circle_outline</mat-icon>
-            </button>
-          </mat-form-field>
-        </div>
+                <mat-autocomplete #auto="matAutocomplete">
+                  <mat-option *ngFor="let result of filterFieldResults" [value]="result">
+                    {{result}}
+                  </mat-option>
+                </mat-autocomplete>
 
-        <div class="form-group" *ngIf="templateValues.part_number  || templateValues.part_number === ''">
-          <mat-label>Part Number</mat-label>
-          <mat-form-field appearance="outline">
-            <input class="form-control" id="part_number" type="text" matInput [(ngModel)]="templateValues.part_number"
-                   placeholder="Part Number" [disabled]="disabled"/>
-            <button mat-icon-button matSuffix (click)="addItem('part_number', templateValues.part_number)" [disabled]="disabled">
-              <mat-icon>add_circle_outline</mat-icon>
-            </button>
-          </mat-form-field>
-        </div>
+              <button mat-icon-button matSuffix (click)="addItem('plant', templateValues.plant)" [disabled]="disabled">
+                <mat-icon>add_circle_outline</mat-icon>
+              </button>
+            </mat-form-field>
+          </div>
 
-        <div class="form-group" *ngIf="templateValues.serial_number  || templateValues.serial_number === ''">
-          <mat-label>Serial Number</mat-label>
-          <mat-form-field appearance="outline">
-            <input class="form-control" id="serial_number" type="text" matInput [disabled]="disabled"
-                   [(ngModel)]="templateValues.serial_number" placeholder="Serial Number"/>
-            <button mat-icon-button matSuffix
-                    (click)="addItem('serial_number', templateValues.serial_number)" [disabled]="disabled">
-              <mat-icon>add_circle_outline</mat-icon>
-            </button>
-          </mat-form-field>
+          <div class="form-group" *ngIf="templateValues.zones  || templateValues.zones === ''">
+            <mat-label>Zones</mat-label>
+            <mat-form-field appearance="outline">
+              <input class="form-control" id="zones" type="text" matInput [(ngModel)]="templateValues.zones"
+                placeholder="Zones" [disabled]="disabled" [matAutocomplete]="auto" formControlName="zones" />
+
+                <mat-autocomplete #auto="matAutocomplete">
+                  <mat-option *ngFor="let result of filterFieldResults" [value]="result">
+                    {{result}}
+                  </mat-option>
+                </mat-autocomplete>
+
+              <button mat-icon-button matSuffix (click)="addItem('zones', templateValues.zones)" [disabled]="disabled">
+                <mat-icon>add_circle_outline</mat-icon>
+              </button>
+            </mat-form-field>
+          </div>
+
+          <div class="form-group" *ngIf="templateValues.aisles  || templateValues.aisles === ''">
+            <mat-label>Aisles</mat-label>
+            <mat-form-field appearance="outline">
+              <input class="form-control" id="aisles" type="text" matInput [(ngModel)]="templateValues.aisles"
+                placeholder="Aisles" [disabled]="disabled" [matAutocomplete]="auto" formControlName="aisles" />
+
+                <mat-autocomplete #auto="matAutocomplete">
+                  <mat-option *ngFor="let result of filterFieldResults" [value]="result">
+                    {{result}}
+                  </mat-option>
+                </mat-autocomplete>
+
+              <button mat-icon-button matSuffix (click)="addItem('aisles', templateValues.aisles)"
+                [disabled]="disabled">
+                <mat-icon>add_circle_outline</mat-icon>
+              </button>
+            </mat-form-field>
+          </div>
+
+          <div class="form-group" *ngIf="templateValues.bins  || templateValues.bins === ''">
+            <mat-label>Bins</mat-label>
+            <mat-form-field appearance="outline">
+              <input class="form-control" id="bins" type="text" matInput [(ngModel)]="templateValues.bins"
+                placeholder="Bins" [disabled]="disabled" [matAutocomplete]="auto" formControlName="bins" />
+
+              <mat-autocomplete #auto="matAutocomplete">
+                <mat-option *ngFor="let result of filterFieldResults" [value]="result">
+                  {{result}}
+                </mat-option>
+              </mat-autocomplete>
+
+              <button mat-icon-button matSuffix (click)="addItem('bins', templateValues.bins)" [disabled]="disabled">
+                <mat-icon>add_circle_outline</mat-icon>
+              </button>
+            </mat-form-field>
+          </div>
+
+          <div class="form-group" *ngIf="templateValues.part_number  || templateValues.part_number === ''">
+            <mat-label>Part Number</mat-label>
+            <mat-form-field appearance="outline">
+              <input class="form-control" id="part_number" type="text" matInput [(ngModel)]="templateValues.part_number"
+                placeholder="Part Number" [disabled]="disabled" [matAutocomplete]="auto"
+                formControlName="part_number" />
+
+                <mat-autocomplete #auto="matAutocomplete">
+                  <mat-option *ngFor="let result of filterFieldResults" [value]="result">
+                    {{result}}
+                  </mat-option>
+                </mat-autocomplete>
+
+              <button mat-icon-button matSuffix (click)="addItem('part_number', templateValues.part_number)"
+                [disabled]="disabled">
+                <mat-icon>add_circle_outline</mat-icon>
+              </button>
+            </mat-form-field>
+          </div>
+
+          <div class="form-group" *ngIf="templateValues.serial_number  || templateValues.serial_number === ''">
+            <mat-label>Serial Number</mat-label>
+            <mat-form-field appearance="outline">
+              <input class="form-control" id="serial_number" type="text" matInput [disabled]="disabled"
+                [(ngModel)]="templateValues.serial_number" placeholder="Serial Number" [matAutocomplete]="auto"
+                formControlName="serial_number" />
+
+              <mat-autocomplete #auto="matAutocomplete">
+                <mat-option *ngFor="let result of filterFieldResults" [value]="result">
+                  {{result}}
+                </mat-option>
+              </mat-autocomplete>
+
+              <button mat-icon-button matSuffix (click)="addItem('serial_number', templateValues.serial_number)"
+                [disabled]="disabled">
+                <mat-icon>add_circle_outline</mat-icon>
+              </button>
+            </mat-form-field>
+          </div>
         </div>
       </div>
 
@@ -107,8 +163,7 @@
         <mat-card-title class="text-align-center">Selected Fields</mat-card-title>
         <mat-chip-list aria-label="Location">
           <div *ngFor="let loc of template | keyvalue">
-            <mat-chip *ngFor="let value of loc.value"
-                      [removable]="true" (removed)="remove(loc.key, value)">
+            <mat-chip *ngFor="let value of loc.value" [removable]="true" (removed)="remove(loc.key, value)">
               {{loc.key.replace('_', ' ') | titlecase}}: {{value}}
               <mat-icon matChipRemove *ngIf="!disabled">cancel</mat-icon>
             </mat-chip>
@@ -117,8 +172,7 @@
       </div>
 
       <mat-form-field appearance="outline">
-          <textarea rows="5" id="description" matInput [(ngModel)]="description"
-                    placeholder="Description"></textarea>
+        <textarea rows="5" id="description" matInput [(ngModel)]="description" placeholder="Description"></textarea>
       </mat-form-field>
 
       <!-- SCHEDULING -->
@@ -131,7 +185,7 @@
         <mat-label>Start Date</mat-label>
         <mat-form-field appearance="outline">
           <input matInput [(ngModel)]="startDate" [matDatepicker]="datePick" disabled class="form-control" id="date"
-                 type="text" placeholder="DD/MM/YYYY">
+            type="text" placeholder="DD/MM/YYYY">
           <mat-datepicker-toggle [for]="datePick" matSuffix class="icon-color"></mat-datepicker-toggle>
           <mat-datepicker #datePick [disabled]="false"></mat-datepicker>
         </mat-form-field>
@@ -141,13 +195,13 @@
         <mat-label>Start time</mat-label>
         <mat-form-field appearance="outline">
           <mat-icon class="icon-color" matSuffix>schedule</mat-icon>
-          <input class="form-control" id="time" type="time" matInput placeholder="Start time" [(ngModel)]="startTime"/>
+          <input class="form-control" id="time" type="time" matInput placeholder="Start time" [(ngModel)]="startTime" />
         </mat-form-field>
       </div>
 
       <mat-accordion class="example-headers-align" multi>
         <mat-expansion-panel class="half-width" [expanded]="panelOpenState" [disabled]="isRecurrenceChosen"
-                             (afterExpand)="recurrenceExpand()" (afterCollapse)="recurrenceCollapsed()">
+          (afterExpand)="recurrenceExpand()" (afterCollapse)="recurrenceCollapsed()">
           <mat-expansion-panel-header>
             <mat-panel-title>Recurrence</mat-panel-title>
           </mat-expansion-panel-header>
@@ -176,13 +230,12 @@
                   <mat-label>On</mat-label>
                 </div>
                 <div class="column-2">
-                  <mat-checkbox class="button-padding" [checked]="allDaysChecked"
-                                [indeterminate]="someCheckboxDay()"
-                                (change)="setAllCheckboxDay($event.checked)">
+                  <mat-checkbox class="button-padding" [checked]="allDaysChecked" [indeterminate]="someCheckboxDay()"
+                    (change)="setAllCheckboxDay($event.checked)">
                     {{recurrenceDay.name}}
                   </mat-checkbox>
                   <mat-checkbox class="button-padding" *ngFor="let subDays of recurrenceDay.subCheckBox"
-                                [(ngModel)]="subDays.checked" (ngModelChange)="updateCheckboxDay()">
+                    [(ngModel)]="subDays.checked" (ngModelChange)="updateCheckboxDay()">
                     {{subDays.name}}
                   </mat-checkbox>
                 </div>
@@ -199,12 +252,11 @@
                 </div>
                 <div class="column-2">
                   <mat-checkbox class="button-padding" [checked]="allMonthsChecked"
-                                [indeterminate]="someCheckboxMonth()"
-                                (change)="setAllCheckboxMonth($event.checked)">
+                    [indeterminate]="someCheckboxMonth()" (change)="setAllCheckboxMonth($event.checked)">
                     {{recurrenceDay.name}}
                   </mat-checkbox>
                   <mat-checkbox class="button-padding" *ngFor="let subMonths of recurrenceMonth.subCheckBox"
-                                [(ngModel)]="subMonths.checked" (ngModelChange)="updateCheckboxMonth()">
+                    [(ngModel)]="subMonths.checked" (ngModelChange)="updateCheckboxMonth()">
                     {{subMonths.name}}
                   </mat-checkbox>
                 </div>

--- a/client/src/app/components/audit-template/audit-template-view/audit-template-view.component.html
+++ b/client/src/app/components/audit-template/audit-template-view/audit-template-view.component.html
@@ -27,7 +27,8 @@
             <mat-label>Location</mat-label>
             <mat-form-field appearance="outline">
               <input class="form-control" id="location" type="text" matInput [(ngModel)]="templateValues.location"
-                placeholder="Location" [disabled]="disabled" [matAutocomplete]="auto" formControlName="Location" />
+                placeholder="Location" [disabled]="disabled" [matAutocomplete]="auto" formControlName="Location"
+                (focus)="onAutoFieldFocusIn($event, 'Location')" (focusout)="onAutoFieldFocusOut($event)" />
 
               <mat-autocomplete #auto="matAutocomplete">
                 <mat-option *ngFor="let result of filterFieldResults" [value]="result">
@@ -46,13 +47,14 @@
             <mat-label>Plant</mat-label>
             <mat-form-field appearance="outline">
               <input class="form-control" id="plant" type="text" matInput [(ngModel)]="templateValues.plant"
-                placeholder="Plant" [disabled]="disabled" [matAutocomplete]="auto" formControlName="Plant" />
+                placeholder="Plant" [disabled]="disabled" [matAutocomplete]="auto" formControlName="Plant"
+                (focus)="onAutoFieldFocusIn($event, 'Plant')" (focusout)="onAutoFieldFocusOut($event)" />
 
-                <mat-autocomplete #auto="matAutocomplete">
-                  <mat-option *ngFor="let result of filterFieldResults" [value]="result">
-                    {{result}}
-                  </mat-option>
-                </mat-autocomplete>
+              <mat-autocomplete #auto="matAutocomplete">
+                <mat-option *ngFor="let result of filterFieldResults" [value]="result">
+                  {{result}}
+                </mat-option>
+              </mat-autocomplete>
 
               <button mat-icon-button matSuffix (click)="addItem('plant', templateValues.plant)" [disabled]="disabled">
                 <mat-icon>add_circle_outline</mat-icon>
@@ -64,13 +66,14 @@
             <mat-label>Zones</mat-label>
             <mat-form-field appearance="outline">
               <input class="form-control" id="zones" type="text" matInput [(ngModel)]="templateValues.zones"
-                placeholder="Zones" [disabled]="disabled" [matAutocomplete]="auto" formControlName="Zone" />
+                placeholder="Zones" [disabled]="disabled" [matAutocomplete]="auto" formControlName="Zone"
+                (focus)="onAutoFieldFocusIn($event, 'Zone')" (focusout)="onAutoFieldFocusOut($event)" />
 
-                <mat-autocomplete #auto="matAutocomplete">
-                  <mat-option *ngFor="let result of filterFieldResults" [value]="result">
-                    {{result}}
-                  </mat-option>
-                </mat-autocomplete>
+              <mat-autocomplete #auto="matAutocomplete">
+                <mat-option *ngFor="let result of filterFieldResults" [value]="result">
+                  {{result}}
+                </mat-option>
+              </mat-autocomplete>
 
               <button mat-icon-button matSuffix (click)="addItem('zones', templateValues.zones)" [disabled]="disabled">
                 <mat-icon>add_circle_outline</mat-icon>
@@ -82,13 +85,14 @@
             <mat-label>Aisles</mat-label>
             <mat-form-field appearance="outline">
               <input class="form-control" id="aisles" type="text" matInput [(ngModel)]="templateValues.aisles"
-                placeholder="Aisles" [disabled]="disabled" [matAutocomplete]="auto" formControlName="Aisle" />
+                placeholder="Aisles" [disabled]="disabled" [matAutocomplete]="auto" formControlName="Aisle"
+                (focus)="onAutoFieldFocusIn($event, 'Aisle')" (focusout)="onAutoFieldFocusOut($event)" />
 
-                <mat-autocomplete #auto="matAutocomplete">
-                  <mat-option *ngFor="let result of filterFieldResults" [value]="result">
-                    {{result}}
-                  </mat-option>
-                </mat-autocomplete>
+              <mat-autocomplete #auto="matAutocomplete">
+                <mat-option *ngFor="let result of filterFieldResults" [value]="result">
+                  {{result}}
+                </mat-option>
+              </mat-autocomplete>
 
               <button mat-icon-button matSuffix (click)="addItem('aisles', templateValues.aisles)"
                 [disabled]="disabled">
@@ -101,7 +105,8 @@
             <mat-label>Bins</mat-label>
             <mat-form-field appearance="outline">
               <input class="form-control" id="bins" type="text" matInput [(ngModel)]="templateValues.bins"
-                placeholder="Bins" [disabled]="disabled" [matAutocomplete]="auto" formControlName="Bin" />
+                placeholder="Bins" [disabled]="disabled" [matAutocomplete]="auto" formControlName="Bin"
+                (focus)="onAutoFieldFocusIn($event, 'Bin')" (focusout)="onAutoFieldFocusOut($event)" />
 
               <mat-autocomplete #auto="matAutocomplete">
                 <mat-option *ngFor="let result of filterFieldResults" [value]="result">
@@ -119,14 +124,14 @@
             <mat-label>Part Number</mat-label>
             <mat-form-field appearance="outline">
               <input class="form-control" id="part_number" type="text" matInput [(ngModel)]="templateValues.part_number"
-                placeholder="Part Number" [disabled]="disabled" [matAutocomplete]="auto"
-                formControlName="Part_Number" />
+                placeholder="Part Number" [disabled]="disabled" [matAutocomplete]="auto" formControlName="Part_Number"
+                (focus)="onAutoFieldFocusIn($event, 'Part_Number')" (focusout)="onAutoFieldFocusOut($event)" />
 
-                <mat-autocomplete #auto="matAutocomplete">
-                  <mat-option *ngFor="let result of filterFieldResults" [value]="result">
-                    {{result}}
-                  </mat-option>
-                </mat-autocomplete>
+              <mat-autocomplete #auto="matAutocomplete">
+                <mat-option *ngFor="let result of filterFieldResults" [value]="result">
+                  {{result}}
+                </mat-option>
+              </mat-autocomplete>
 
               <button mat-icon-button matSuffix (click)="addItem('part_number', templateValues.part_number)"
                 [disabled]="disabled">
@@ -140,7 +145,8 @@
             <mat-form-field appearance="outline">
               <input class="form-control" id="serial_number" type="text" matInput [disabled]="disabled"
                 [(ngModel)]="templateValues.serial_number" placeholder="Serial Number" [matAutocomplete]="auto"
-                formControlName="Serial_Number"/>
+                formControlName="Serial_Number" (focus)="onAutoFieldFocusIn($event, 'Serial_Number')"
+                (focusout)="onAutoFieldFocusOut($event)" />
 
               <mat-autocomplete #auto="matAutocomplete">
                 <mat-option *ngFor="let result of filterFieldResults" [value]="result">

--- a/client/src/app/components/audit-template/audit-template-view/audit-template-view.component.html
+++ b/client/src/app/components/audit-template/audit-template-view/audit-template-view.component.html
@@ -27,8 +27,8 @@
             <mat-label>Location</mat-label>
             <mat-form-field appearance="outline">
               <input class="form-control" id="location" type="text" matInput [(ngModel)]="templateValues.location"
-                placeholder="Location" [disabled]="disabled" [matAutocomplete]="auto" formControlName="Location"
-                (focus)="onAutoFieldFocusIn($event, 'Location')" (focusout)="onAutoFieldFocusOut($event)" />
+                placeholder="Location" [disabled]="disabled" [matAutocomplete]="auto" onclick="this.blur()"
+                [formControlName]="AutoFields.LOCATION" (focus)="onAutoFieldFocusIn($event, AutoFields.LOCATION)" />
 
               <mat-autocomplete #auto="matAutocomplete">
                 <mat-option *ngFor="let result of filterFieldResults" [value]="result">
@@ -47,8 +47,8 @@
             <mat-label>Plant</mat-label>
             <mat-form-field appearance="outline">
               <input class="form-control" id="plant" type="text" matInput [(ngModel)]="templateValues.plant"
-                placeholder="Plant" [disabled]="disabled" [matAutocomplete]="auto" formControlName="Plant"
-                (focus)="onAutoFieldFocusIn($event, 'Plant')" (focusout)="onAutoFieldFocusOut($event)" />
+                placeholder="Plant" [disabled]="disabled" [matAutocomplete]="auto" [formControlName]="AutoFields.PLANT"
+                (focus)="onAutoFieldFocusIn($event, AutoFields.PLANT)" onclick="this.blur()"/>
 
               <mat-autocomplete #auto="matAutocomplete">
                 <mat-option *ngFor="let result of filterFieldResults" [value]="result">
@@ -66,8 +66,8 @@
             <mat-label>Zones</mat-label>
             <mat-form-field appearance="outline">
               <input class="form-control" id="zones" type="text" matInput [(ngModel)]="templateValues.zones"
-                placeholder="Zones" [disabled]="disabled" [matAutocomplete]="auto" formControlName="Zone"
-                (focus)="onAutoFieldFocusIn($event, 'Zone')" (focusout)="onAutoFieldFocusOut($event)" />
+                placeholder="Zones" [disabled]="disabled" [matAutocomplete]="auto" [formControlName]="AutoFields.ZONE"
+                (focus)="onAutoFieldFocusIn($event, AutoFields.ZONE)" />
 
               <mat-autocomplete #auto="matAutocomplete">
                 <mat-option *ngFor="let result of filterFieldResults" [value]="result">
@@ -85,8 +85,8 @@
             <mat-label>Aisles</mat-label>
             <mat-form-field appearance="outline">
               <input class="form-control" id="aisles" type="text" matInput [(ngModel)]="templateValues.aisles"
-                placeholder="Aisles" [disabled]="disabled" [matAutocomplete]="auto" formControlName="Aisle"
-                (focus)="onAutoFieldFocusIn($event, 'Aisle')" (focusout)="onAutoFieldFocusOut($event)" />
+                placeholder="Aisles" [disabled]="disabled" [matAutocomplete]="auto" [formControlName]="AutoFields.AISLE"
+                (focus)="onAutoFieldFocusIn($event, AutoFields.AISLE)" />
 
               <mat-autocomplete #auto="matAutocomplete">
                 <mat-option *ngFor="let result of filterFieldResults" [value]="result">
@@ -105,8 +105,8 @@
             <mat-label>Bins</mat-label>
             <mat-form-field appearance="outline">
               <input class="form-control" id="bins" type="text" matInput [(ngModel)]="templateValues.bins"
-                placeholder="Bins" [disabled]="disabled" [matAutocomplete]="auto" formControlName="Bin"
-                (focus)="onAutoFieldFocusIn($event, 'Bin')" (focusout)="onAutoFieldFocusOut($event)" />
+                placeholder="Bins" [disabled]="disabled" [matAutocomplete]="auto" [formControlName]="AutoFields.BIN"
+                (focus)="onAutoFieldFocusIn($event, AutoFields.BIN)" />
 
               <mat-autocomplete #auto="matAutocomplete">
                 <mat-option *ngFor="let result of filterFieldResults" [value]="result">
@@ -124,8 +124,9 @@
             <mat-label>Part Number</mat-label>
             <mat-form-field appearance="outline">
               <input class="form-control" id="part_number" type="text" matInput [(ngModel)]="templateValues.part_number"
-                placeholder="Part Number" [disabled]="disabled" [matAutocomplete]="auto" formControlName="Part_Number"
-                (focus)="onAutoFieldFocusIn($event, 'Part_Number')" (focusout)="onAutoFieldFocusOut($event)" />
+                placeholder="Part Number" [disabled]="disabled" [matAutocomplete]="auto"
+                [formControlName]="AutoFields.PART_NUMBER"
+                (focus)="onAutoFieldFocusIn($event, AutoFields.PART_NUMBER)" />
 
               <mat-autocomplete #auto="matAutocomplete">
                 <mat-option *ngFor="let result of filterFieldResults" [value]="result">
@@ -145,8 +146,8 @@
             <mat-form-field appearance="outline">
               <input class="form-control" id="serial_number" type="text" matInput [disabled]="disabled"
                 [(ngModel)]="templateValues.serial_number" placeholder="Serial Number" [matAutocomplete]="auto"
-                formControlName="Serial_Number" (focus)="onAutoFieldFocusIn($event, 'Serial_Number')"
-                (focusout)="onAutoFieldFocusOut($event)" />
+                [formControlName]="AutoFields.SERIAL_NUMBER"
+                (focus)="onAutoFieldFocusIn($event,AutoFields.SERIAL_NUMBER)" />
 
               <mat-autocomplete #auto="matAutocomplete">
                 <mat-option *ngFor="let result of filterFieldResults" [value]="result">

--- a/client/src/app/components/audit-template/audit-template-view/audit-template-view.component.html
+++ b/client/src/app/components/audit-template/audit-template-view/audit-template-view.component.html
@@ -27,7 +27,7 @@
             <mat-label>Location</mat-label>
             <mat-form-field appearance="outline">
               <input class="form-control" id="location" type="text" matInput [(ngModel)]="templateValues.location"
-                placeholder="Location" [disabled]="disabled" [matAutocomplete]="auto" formControlName="location" />
+                placeholder="Location" [disabled]="disabled" [matAutocomplete]="auto" formControlName="Location" />
 
               <mat-autocomplete #auto="matAutocomplete">
                 <mat-option *ngFor="let result of filterFieldResults" [value]="result">
@@ -46,7 +46,7 @@
             <mat-label>Plant</mat-label>
             <mat-form-field appearance="outline">
               <input class="form-control" id="plant" type="text" matInput [(ngModel)]="templateValues.plant"
-                placeholder="Plant" [disabled]="disabled" [matAutocomplete]="auto" formControlName="plant" />
+                placeholder="Plant" [disabled]="disabled" [matAutocomplete]="auto" formControlName="Plant" />
 
                 <mat-autocomplete #auto="matAutocomplete">
                   <mat-option *ngFor="let result of filterFieldResults" [value]="result">
@@ -64,7 +64,7 @@
             <mat-label>Zones</mat-label>
             <mat-form-field appearance="outline">
               <input class="form-control" id="zones" type="text" matInput [(ngModel)]="templateValues.zones"
-                placeholder="Zones" [disabled]="disabled" [matAutocomplete]="auto" formControlName="zones" />
+                placeholder="Zones" [disabled]="disabled" [matAutocomplete]="auto" formControlName="Zone" />
 
                 <mat-autocomplete #auto="matAutocomplete">
                   <mat-option *ngFor="let result of filterFieldResults" [value]="result">
@@ -82,7 +82,7 @@
             <mat-label>Aisles</mat-label>
             <mat-form-field appearance="outline">
               <input class="form-control" id="aisles" type="text" matInput [(ngModel)]="templateValues.aisles"
-                placeholder="Aisles" [disabled]="disabled" [matAutocomplete]="auto" formControlName="aisles" />
+                placeholder="Aisles" [disabled]="disabled" [matAutocomplete]="auto" formControlName="Aisle" />
 
                 <mat-autocomplete #auto="matAutocomplete">
                   <mat-option *ngFor="let result of filterFieldResults" [value]="result">
@@ -101,7 +101,7 @@
             <mat-label>Bins</mat-label>
             <mat-form-field appearance="outline">
               <input class="form-control" id="bins" type="text" matInput [(ngModel)]="templateValues.bins"
-                placeholder="Bins" [disabled]="disabled" [matAutocomplete]="auto" formControlName="bins" />
+                placeholder="Bins" [disabled]="disabled" [matAutocomplete]="auto" formControlName="Bin" />
 
               <mat-autocomplete #auto="matAutocomplete">
                 <mat-option *ngFor="let result of filterFieldResults" [value]="result">
@@ -120,7 +120,7 @@
             <mat-form-field appearance="outline">
               <input class="form-control" id="part_number" type="text" matInput [(ngModel)]="templateValues.part_number"
                 placeholder="Part Number" [disabled]="disabled" [matAutocomplete]="auto"
-                formControlName="part_number" />
+                formControlName="Part_Number" />
 
                 <mat-autocomplete #auto="matAutocomplete">
                   <mat-option *ngFor="let result of filterFieldResults" [value]="result">
@@ -140,7 +140,7 @@
             <mat-form-field appearance="outline">
               <input class="form-control" id="serial_number" type="text" matInput [disabled]="disabled"
                 [(ngModel)]="templateValues.serial_number" placeholder="Serial Number" [matAutocomplete]="auto"
-                formControlName="serial_number" />
+                formControlName="Serial_Number"/>
 
               <mat-autocomplete #auto="matAutocomplete">
                 <mat-option *ngFor="let result of filterFieldResults" [value]="result">

--- a/client/src/app/components/audit-template/audit-template-view/audit-template-view.component.ts
+++ b/client/src/app/components/audit-template/audit-template-view/audit-template-view.component.ts
@@ -235,7 +235,9 @@ export abstract class AuditTemplateViewComponent implements OnInit {
       formGroup[field] = new FormControl();
       formGroup[field].valueChanges.subscribe(
         async (val: any) => {
-          this.filter(val, field);
+          if (val !== '') {
+            this.filter(val, field);
+          }
         }
       );
     });
@@ -259,5 +261,13 @@ export abstract class AuditTemplateViewComponent implements OnInit {
         this.filterFieldResults = [...new Set(filtered)].sort(); // Sorted Without Duplicates
       }
     );
+  }
+
+  onAutoFieldFocusIn(event: any, field: string) {
+    this.filter(event.target?.value, field);
+  }
+
+  onAutoFieldFocusOut(event: any){
+    this.filterFieldResults = [];
   }
 }

--- a/client/src/app/components/audit-template/audit-template-view/audit-template-view.component.ts
+++ b/client/src/app/components/audit-template/audit-template-view/audit-template-view.component.ts
@@ -1,5 +1,6 @@
-import {Component, OnInit} from '@angular/core';
-import {Template} from '../Template';
+import { Component, OnInit } from '@angular/core';
+import { FormControl, FormGroup } from '@angular/forms';
+import { Template } from '../Template';
 import timeZones from '../audit-template-view/create-audit-template/timezone.json';
 
 interface DaysCheckBox {
@@ -84,11 +85,24 @@ export abstract class AuditTemplateViewComponent implements OnInit {
   title = '';
   description = '';
 
+  autocompleteFormGroup: FormGroup | undefined;
+  filterFieldResults: string[] | undefined;
+  autoCompletePool: string[] = ['demo', 'angular', 'django'];
+  autoFields = [
+    'location',
+    'plant',
+    'zones',
+    'aisles',
+    'bins',
+    'part_number',
+    'serial_number'
+  ];
 
   protected constructor() { }
 
   ngOnInit(): void {
     this.initializeForm();
+    this.initAutocomplete();
   }
 
   abstract initializeForm(): void;
@@ -156,57 +170,78 @@ export abstract class AuditTemplateViewComponent implements OnInit {
   }
 
   updateCheckboxDay(): void {
-      this.allDaysChecked =
-        this.recurrenceDay.subCheckBox != null &&
-        this.recurrenceDay.subCheckBox.every((t) => t.checked);
-      this.errorMessageCheckboxDay = ' ';
+    this.allDaysChecked =
+      this.recurrenceDay.subCheckBox != null &&
+      this.recurrenceDay.subCheckBox.every((t) => t.checked);
+    this.errorMessageCheckboxDay = ' ';
   }
 
   updateCheckboxMonth(): void {
-      this.allMonthsChecked =
-        this.recurrenceMonth.subCheckBox != null &&
-        this.recurrenceMonth.subCheckBox.every((t) => t.checked);
-      this.errorMessageCheckboxMonth = ' ';
+    this.allMonthsChecked =
+      this.recurrenceMonth.subCheckBox != null &&
+      this.recurrenceMonth.subCheckBox.every((t) => t.checked);
+    this.errorMessageCheckboxMonth = ' ';
   }
 
   // @ts-ignore
   someCheckboxDay(): boolean {
-      if (this.recurrenceDay.subCheckBox == null) {
-        return false;
-      }
-      return (
-        this.recurrenceDay.subCheckBox.filter((t) => t.checked).length > 0 &&
-        !this.allDaysChecked
-      );
+    if (this.recurrenceDay.subCheckBox == null) {
+      return false;
+    }
+    return (
+      this.recurrenceDay.subCheckBox.filter((t) => t.checked).length > 0 &&
+      !this.allDaysChecked
+    );
   }
 
   // @ts-ignore
   someCheckboxMonth(): boolean {
-      if (this.recurrenceMonth.subCheckBox == null) {
-        return false;
-      }
-      return (
-        this.recurrenceMonth.subCheckBox.filter((t) => t.checked).length > 0 &&
-        !this.allMonthsChecked
-      );
+    if (this.recurrenceMonth.subCheckBox == null) {
+      return false;
+    }
+    return (
+      this.recurrenceMonth.subCheckBox.filter((t) => t.checked).length > 0 &&
+      !this.allMonthsChecked
+    );
   }
 
   setAllCheckboxDay(checked: boolean): void {
-      this.allDaysChecked = checked;
-      if (this.recurrenceDay.subCheckBox == null) {
-        return;
-      }
-      this.recurrenceDay.subCheckBox.forEach((t) => (t.checked = checked));
+    this.allDaysChecked = checked;
+    if (this.recurrenceDay.subCheckBox == null) {
+      return;
+    }
+    this.recurrenceDay.subCheckBox.forEach((t) => (t.checked = checked));
   }
 
   setAllCheckboxMonth(checked: boolean): void {
-      this.allMonthsChecked = checked;
-      if (this.recurrenceMonth.subCheckBox == null) {
-        return;
-      }
-      this.recurrenceMonth.subCheckBox.forEach((t) => (t.checked = checked));
+    this.allMonthsChecked = checked;
+    if (this.recurrenceMonth.subCheckBox == null) {
+      return;
+    }
+    this.recurrenceMonth.subCheckBox.forEach((t) => (t.checked = checked));
   }
 
   abstract submitQuery(body: any): void;
+
+
+  initAutocomplete(): void {
+    const formGroup: any = {};
+    this.autoFields.forEach(field => {
+      formGroup[field] = new FormControl();
+      formGroup[field].valueChanges.subscribe(
+        (val: any) => {
+          this.filterFieldResults = this.filter(val, field);
+        }
+      );
+    });
+    this.autocompleteFormGroup = new FormGroup(formGroup);
+  }
+
+  filter(val: string, field: any): string[] {
+    const value = val.toLowerCase();
+    return this.autoCompletePool.filter(element =>
+      element.toLowerCase().includes(value)
+    );
+  }
 
 }

--- a/client/src/app/components/audit-template/audit-template-view/audit-template-view.component.ts
+++ b/client/src/app/components/audit-template/audit-template-view/audit-template-view.component.ts
@@ -17,6 +17,16 @@ interface MonthsCheckBox {
   subCheckBox?: MonthsCheckBox[];
 }
 
+enum AutoFields {
+  LOCATION = 'Location',
+  PLANT = 'Plant',
+  ZONE = 'Zone',
+  AISLE = 'Aisle',
+  BIN = 'Bin',
+  PART_NUMBER = 'Part_Number',
+  SERIAL_NUMBER = 'Serial_Number'
+}
+
 @Component({
   template: ''
 })
@@ -88,18 +98,9 @@ export abstract class AuditTemplateViewComponent implements OnInit {
   description = '';
 
   params = new HttpParams();
+  AutoFields = AutoFields;
   autocompleteFormGroup: FormGroup | undefined;
   filterFieldResults: string[] | undefined;
-
-  autoFields = [
-    'Location',
-    'Plant',
-    'Zone',
-    'Aisle',
-    'Bin',
-    'Part_Number',
-    'Serial_Number'
-  ];
 
   constructor(
     private itemsService: ManageInventoryItemsService
@@ -231,7 +232,7 @@ export abstract class AuditTemplateViewComponent implements OnInit {
 
   initAutocomplete(): void {
     const formGroup: any = {};
-    this.autoFields.forEach(field => {
+    Object.values(this.AutoFields).forEach(field => {
       formGroup[field] = new FormControl();
       formGroup[field].valueChanges.subscribe(
         async (val: any) => {
@@ -245,6 +246,7 @@ export abstract class AuditTemplateViewComponent implements OnInit {
   }
 
   filter(value: string, field: string): void {
+    this.filterFieldResults = [];
     const val = value.toLowerCase();
     this.params = new HttpParams();
     this.params = this.params.set('page', '1');
@@ -258,16 +260,14 @@ export abstract class AuditTemplateViewComponent implements OnInit {
           (element: string) =>
             element.toLowerCase().includes(val)
         );
-        this.filterFieldResults = [...new Set(filtered)].sort(); // Sorted Without Duplicates
+        setTimeout(() => {
+          this.filterFieldResults = [...new Set(filtered)].sort(); // Sorted Without Duplicates
+        }, 100);
       }
     );
   }
 
-  onAutoFieldFocusIn(event: any, field: string) {
+  onAutoFieldFocusIn(event: any, field: string): void {
     this.filter(event.target?.value, field);
-  }
-
-  onAutoFieldFocusOut(event: any){
-    this.filterFieldResults = [];
   }
 }

--- a/client/src/app/components/audit-template/audit-template-view/create-audit-template/create-audit-template.component.spec.ts
+++ b/client/src/app/components/audit-template/audit-template-view/create-audit-template/create-audit-template.component.spec.ts
@@ -4,6 +4,7 @@ import { FormBuilder } from '@angular/forms';
 import { RouterTestingModule } from '@angular/router/testing';
 import { CreateAuditTemplateComponent } from './create-audit-template.component';
 import { AuditTemplateService } from 'src/app/services/audits/audit-template.service';
+import { MatAutocompleteModule } from '@angular/material/autocomplete';
 
 describe('AuditTemplateComponent', () => {
   let component: CreateAuditTemplateComponent;
@@ -12,7 +13,11 @@ describe('AuditTemplateComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [CreateAuditTemplateComponent],
-      imports: [HttpClientTestingModule, RouterTestingModule],
+      imports: [
+        HttpClientTestingModule,
+        RouterTestingModule,
+        MatAutocompleteModule
+      ],
       providers: [
         FormBuilder,
         {

--- a/client/src/app/components/audit-template/audit-template-view/create-audit-template/create-audit-template.component.ts
+++ b/client/src/app/components/audit-template/audit-template-view/create-audit-template/create-audit-template.component.ts
@@ -3,6 +3,7 @@ import { Router } from '@angular/router';
 import { AuditTemplateService } from '../../../../services/audits/audit-template.service';
 import { Template } from '../../Template';
 import { AuditTemplateViewComponent } from '../audit-template-view.component';
+import {ManageInventoryItemsService} from 'src/app/services/inventory-items/manage-inventory-items.service';
 
 @Component({
   selector: 'app-create-audit-template',
@@ -16,8 +17,9 @@ export class CreateAuditTemplateComponent extends AuditTemplateViewComponent {
   constructor(
     private router: Router,
     private auditTemplateService: AuditTemplateService,
+    itemsService: ManageInventoryItemsService
   ) {
-    super();
+    super(itemsService);
   }
 
   initializeForm(): void {

--- a/client/src/app/components/audit-template/audit-template-view/edit-audit-template/edit-audit-template.component.spec.ts
+++ b/client/src/app/components/audit-template/audit-template-view/edit-audit-template/edit-audit-template.component.spec.ts
@@ -4,6 +4,7 @@ import { FormBuilder } from '@angular/forms';
 import { RouterTestingModule } from '@angular/router/testing';
 import { EditAuditTemplateComponent } from './edit-audit-template.component';
 import { AuditTemplateService } from 'src/app/services/audits/audit-template.service';
+import { MatAutocompleteModule } from '@angular/material/autocomplete';
 
 describe('AuditTemplateComponent', () => {
   let component: EditAuditTemplateComponent;
@@ -12,7 +13,11 @@ describe('AuditTemplateComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [EditAuditTemplateComponent],
-      imports: [HttpClientTestingModule, RouterTestingModule],
+      imports: [
+        HttpClientTestingModule,
+        RouterTestingModule,
+        MatAutocompleteModule
+      ],
       providers: [
         FormBuilder,
         {

--- a/client/src/app/components/audit-template/audit-template-view/edit-audit-template/edit-audit-template.component.ts
+++ b/client/src/app/components/audit-template/audit-template-view/edit-audit-template/edit-audit-template.component.ts
@@ -3,6 +3,7 @@ import { AuditTemplateService } from '../../../../services/audits/audit-template
 import { ActivatedRoute } from '@angular/router';
 import {AuditTemplateViewComponent} from '../audit-template-view.component';
 import { Template } from '../../Template';
+import {ManageInventoryItemsService} from 'src/app/services/inventory-items/manage-inventory-items.service';
 
 @Component({
   selector: 'app-edit-audit-template',
@@ -17,8 +18,9 @@ export class EditAuditTemplateComponent extends AuditTemplateViewComponent {
   constructor(
     private auditTemplateService: AuditTemplateService,
     private activatedRoute: ActivatedRoute,
+    itemsService: ManageInventoryItemsService
   ) {
-    super();
+    super(itemsService);
   }
 
   initializeForm(): void {

--- a/client/src/app/modules/material/material-module.ts
+++ b/client/src/app/modules/material/material-module.ts
@@ -15,6 +15,7 @@ import { MatListModule } from '@angular/material/list';
 import { MatGridListModule } from '@angular/material/grid-list';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatExpansionModule } from '@angular/material/expansion';
+import { MatAutocompleteModule } from '@angular/material/autocomplete';
 import { DragDropModule } from '@angular/cdk/drag-drop';
 
 @NgModule({
@@ -34,7 +35,8 @@ import { DragDropModule } from '@angular/cdk/drag-drop';
     MatDividerModule,
     MatListModule,
     MatCheckboxModule,
-    MatGridListModule
+    MatGridListModule,
+    MatAutocompleteModule,
   ],
   providers: [],
   exports: [
@@ -55,6 +57,7 @@ import { DragDropModule } from '@angular/cdk/drag-drop';
     MatCheckboxModule,
     MatExpansionModule,
     DragDropModule,
+    MatAutocompleteModule,
   ]
 })
 export class MatModule {}

--- a/server/inventory_item/views.py
+++ b/server/inventory_item/views.py
@@ -44,15 +44,12 @@ class CustomSearchFilter(filters.SearchFilter):
 
         for field in filterset_iexact_fields:
             if field in request.query_params:
-                param = {'{0}__{1}'.format(field, 'iexact'): request.query_params[field]}
+                param = {'{0}__{1}'.format(field, 'icontains'): request.query_params[field]}
                 queryset = queryset.filter(**param)
         return queryset
 
 
 class ItemViewSet(LoggingViewset):
-    """
-    API endpoint that allows organizations to be viewed or edited.
-    """
     queryset = Item.objects.all().order_by('Batch_Number')
     serializer_class = ItemSerializer
     http_method_names = ['get']


### PR DESCRIPTION
On the add audit template page, the following input fields now support autocomplete results: 
- Location
- Plant
- Zone
- Aisle
- Part_Number
- Serial_Number
Note: Aisle will not currently display anything as the django filtering only supports char types and Aisle is an integer field. 

The filtering query has been changed to use  icontains (matches substrings instead of exact matches).
The top 6 results will show in the dropdown. Results are filtered automatically as the user types in characters. Blank input will still show 6 results.
Built using the MatAutoComplete angular module: https://material.angular.io/components/autocomplete/overview